### PR TITLE
feat: pre-release polish — i18n, UX, code quality, theming, docs

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -37,7 +37,11 @@ The app offers a set of tools, each of which occupies the entire secondary scree
 - **Trackpoint:** Analoger Zeiger-Cursor, der Mausbewegungen auf dem primären Display simuliert – steuerbar direkt über die Tastatur.
 - **Key Repeat:** Konfigurierbare Wiederholungsrate für gehaltene Tasten; bei deaktiviertem Repeat wird Key-Up sofort gesendet, um das Kernel-Repeat zu unterdrücken.
 - Eingaben werden in Echtzeit via nativem Binary direkt in `/dev/uinput` injiziert (< 1 ms Latenz).
+### 2.5 MacroPad → [docs/features/macropad/FEATURE.md](docs/features/macropad/FEATURE.md)
 
+- Frei konfigurierbares Button-Pad mit mehreren benannten Profilen und freier Positionierung.
+- Unterstützte Aktionstypen: Tastatur-Taste, Gamepad-Button (via virtuellem uinput-Gamepad), Maus-Links-/Rechtsklick, Scroll-Wheel und Trackpoint (relative Mausbewegung).
+- Layouts werden im integrierten Editor (Drag & Drop, Größenauswahl, Beschriftung) erstellt und als JSON in DataStore persistiert.
 ## 3. User Interface & User Experience (UX)
 
 - **Launch behaviour:** On opening the app, it starts immediately in Mirror mode to provide instant value without any configuration.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Given its hardware-specific approach, this project is extensively documented:
 3. **Gallery-Style Pan & Zoom:** Natural and smart multi-touch gestures with exact physical boundary constraints (_Hard Edges_ to prevent vanishing windows) and auto-centering (Pinch-Out Snap-Back).
 4. **Resource-Efficient Freeze Frame:** Physically decouples the video producer from the renderer to freeze frames in the hardware buffer with zero CPU overhead while retaining full zoom capabilities.
 5. **Virtual Keyboard:** Full QWERTZ/QWERTY/AZERTY keyboard with multi-state modifier keys, an integrated trackpoint, and sub-millisecond key injection via a native binary directly into `/dev/uinput`.
-6. **MacroPad:** Fully configurable button pad with multiple named profiles, free-placement buttons, and five action types — keyboard key, gamepad button (virtual uinput gamepad), mouse left/right click, and a trackpoint area for relative mouse movement.
+6. **MacroPad:** Fully configurable button pad with multiple named profiles, free-placement buttons, and five action types — keyboard key, gamepad button (virtual uinput gamepad), mouse left/right click, and a trackpoint area for relative mouse movement. See [docs/features/macropad/FEATURE.md](docs/features/macropad/FEATURE.md).
 
 ---
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,11 +13,12 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Megingiard" >
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="keyboard|keyboardHidden|navigation"
+            android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout|smallestScreenSize"
             android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/stormpanda/megingiard/AppStateManager.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/AppStateManager.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.launch
 enum class AppMode { MIRROR, MEDIA, TOUCHPAD, KEYBOARD, MACROPAD }
 
 object AppStateManager {
+    // App-lifetime scope: intentionally never cancelled — this singleton lives for the
+    // duration of the process. Cancellation is handled by process termination.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private val _currentMode = MutableStateFlow(AppMode.MIRROR)

--- a/app/src/main/java/com/stormpanda/megingiard/MainActivity.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.stormpanda.megingiard
 
 import android.app.ActivityOptions
+import android.app.LocaleManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.LocaleList
 import android.provider.Settings
 import android.view.Display
 import android.view.WindowManager
@@ -37,10 +39,13 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.stormpanda.megingiard.mirror.ScreenCaptureManager
+import com.stormpanda.megingiard.settings.AppLanguage
 import com.stormpanda.megingiard.settings.SettingsManager
 import com.stormpanda.megingiard.ui.LocalAppColors
 import com.stormpanda.megingiard.ui.colorSchemeFor
 import com.stormpanda.megingiard.ui.paletteFor
+import java.util.Locale
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -76,6 +81,19 @@ class MainActivity : ComponentActivity() {
             }
         }
         SettingsManager.init(this)
+        lifecycleScope.launch {
+            SettingsManager.appLanguage.drop(1).collect { lang ->
+                val desired = when (lang) {
+                    AppLanguage.SYSTEM -> LocaleList.getEmptyLocaleList()
+                    AppLanguage.EN     -> LocaleList(Locale.ENGLISH)
+                    AppLanguage.DE     -> LocaleList(Locale.GERMAN)
+                }
+                val localeManager = getSystemService(LocaleManager::class.java)
+                if (localeManager.applicationLocales != desired) {
+                    localeManager.applicationLocales = desired
+                }
+            }
+        }
         enableEdgeToEdge()
         setContent {
             var hasNotificationAccess by remember { mutableStateOf(isNotificationListenerEnabled(this@MainActivity)) }

--- a/app/src/main/java/com/stormpanda/megingiard/MainAppScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/MainAppScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput

--- a/app/src/main/java/com/stormpanda/megingiard/MainAppScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/MainAppScreen.kt
@@ -1,5 +1,7 @@
 package com.stormpanda.megingiard
 
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -10,19 +12,25 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -51,6 +59,10 @@ fun MainAppScreen() {
     val density = LocalDensity.current
     val edgeZonePx = with(density) { MAS_SWIPE_EDGE_ZONE.toPx() }
     val swipeThresholdPx = with(density) { MAS_SWIPE_THRESHOLD.toPx() }
+
+    val context = LocalContext.current
+    var showExitDialog by remember { mutableStateOf(false) }
+    BackHandler { showExitDialog = true }
 
     Box(
         modifier = Modifier
@@ -149,6 +161,25 @@ fun MainAppScreen() {
         }
 
         CarouselOverlay(visible = showControls, onInteraction = { AppStateManager.triggerOverlay() })
+    }
+
+    if (showExitDialog) {
+        AlertDialog(
+            onDismissRequest = { showExitDialog = false },
+            title = { Text(stringResource(R.string.exit_dialog_title), color = colors.onSurface) },
+            text = { Text(stringResource(R.string.exit_dialog_message), color = colors.onSurface) },
+            confirmButton = {
+                TextButton(onClick = { (context as ComponentActivity).finishAndRemoveTask() }) {
+                    Text(stringResource(R.string.exit_dialog_confirm), color = colors.accent)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showExitDialog = false }) {
+                    Text(stringResource(R.string.exit_dialog_cancel), color = colors.accent)
+                }
+            },
+            containerColor = colors.surface,
+        )
     }
 }
 

--- a/app/src/main/java/com/stormpanda/megingiard/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/keyboard/KeyboardScreen.kt
@@ -1,5 +1,6 @@
 package com.stormpanda.megingiard.keyboard
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -341,41 +342,50 @@ fun KeyboardScreen(modifier: Modifier = Modifier) {
                 }
             }
     ) {
-        // Visual keyboard layout
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    start = 4.dp,
-                    end = 4.dp,
-                    top = if (overlayAtBottom) 4.dp else CAROUSEL_PILL_INSET,
-                    bottom = if (kbFullscreen) (if (overlayAtBottom) CAROUSEL_PILL_INSET else 4.dp) else KB_IME_BOTTOM_PADDING
-                ),
-            verticalArrangement = Arrangement.SpaceEvenly
-        ) {
-            layout.forEachIndexed { rowIndex, row ->
-                val heightWeight = if (rowIndex == 0) F_ROW_HEIGHT_WEIGHT else 1f
-                Row(
-                    modifier = Modifier
-                        .weight(heightWeight)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(KEY_PADDING_H)
-                ) {
-                    row.forEach { key ->
-                        // Skip trackpoint key if disabled in settings
-                        if (key.type == KeyType.TRACKPOINT && !kbTrackpointEnabled) return@forEach
-                        val modState by KeyboardState.stateFor(key.id).collectAsState()
-                        KeyCap(
-                            keyDef = key,
-                            isPressed = key.id in pressedKeys,
-                            modifierState = modState,
-                            accentColor = accentColor,
-                            isShiftActive = isShiftActive,
-                            isCapsActive = isCapsActive,
-                            isAltGrActive = isAltGrActive,
-                            modifier = Modifier.weight(key.widthWeight),
-                            onBoundsUpdate = { bounds -> keyBounds[key.id] = bounds }
-                        )
+        // Visual keyboard layout — Crossfade for smooth layout transitions
+        Crossfade(targetState = kbLayout, label = "Layout Switch") { activeLayout ->
+            val animatedLayout = remember(activeLayout) {
+                when (activeLayout) {
+                    KbLayout.QWERTY -> qwertyLayout()
+                    KbLayout.AZERTY -> azertyLayout()
+                    KbLayout.QWERTZ -> qwertzLayout()
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = 4.dp,
+                        end = 4.dp,
+                        top = if (overlayAtBottom) 4.dp else CAROUSEL_PILL_INSET,
+                        bottom = if (kbFullscreen) (if (overlayAtBottom) CAROUSEL_PILL_INSET else 4.dp) else KB_IME_BOTTOM_PADDING
+                    ),
+                verticalArrangement = Arrangement.SpaceEvenly
+            ) {
+                animatedLayout.forEachIndexed { rowIndex, row ->
+                    val heightWeight = if (rowIndex == 0) F_ROW_HEIGHT_WEIGHT else 1f
+                    Row(
+                        modifier = Modifier
+                            .weight(heightWeight)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(KEY_PADDING_H)
+                    ) {
+                        row.forEach { key ->
+                            // Skip trackpoint key if disabled in settings
+                            if (key.type == KeyType.TRACKPOINT && !kbTrackpointEnabled) return@forEach
+                            val modState by KeyboardState.stateFor(key.id).collectAsState()
+                            KeyCap(
+                                keyDef = key,
+                                isPressed = key.id in pressedKeys,
+                                modifierState = modState,
+                                accentColor = accentColor,
+                                isShiftActive = isShiftActive,
+                                isCapsActive = isCapsActive,
+                                isAltGrActive = isAltGrActive,
+                                modifier = Modifier.weight(key.widthWeight),
+                                onBoundsUpdate = { bounds -> keyBounds[key.id] = bounds }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/stormpanda/megingiard/keyboard/ShellKeyInjector.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/keyboard/ShellKeyInjector.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import java.io.BufferedWriter
 import java.io.File
 import java.io.OutputStreamWriter
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -61,7 +62,8 @@ object ShellKeyInjector {
             // Read the readiness signal with a bounded timeout so a binary that
             // never prints "R" doesn't hang the caller indefinitely.
             val reader = p.inputStream.bufferedReader()
-            val readyFuture = java.util.concurrent.Executors.newSingleThreadExecutor().submit<String?> {
+            val executor = Executors.newSingleThreadExecutor()
+            val readyFuture = executor.submit<String?> {
                 try { reader.readLine() } catch (_: Exception) { null }
             }
             val ready = try {
@@ -71,6 +73,8 @@ object ShellKeyInjector {
                 readyFuture.cancel(true)
                 p.destroy()
                 return
+            } finally {
+                executor.shutdownNow()
             }
             if (ready != "R") {
                 Log.e(TAG, "Unexpected ready signal: $ready")

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/MacroPadState.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/MacroPadState.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.flow.stateIn
  */
 object MacroPadState {
 
+    // App-lifetime scope: intentionally never cancelled — this singleton lives for the
+    // duration of the process. Cancellation is handled by process termination.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     // -------------------------------------------------------------------------

--- a/app/src/main/java/com/stormpanda/megingiard/media/MediaScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/media/MediaScreen.kt
@@ -67,6 +67,7 @@ fun formatTime(ms: Long): String {
 
 @Composable
 fun MediaScreen(modifier: Modifier = Modifier) {
+    val hasActiveMedia by MediaState.hasActiveMedia.collectAsState()
     val title by MediaState.currentTitle.collectAsState()
     val isPlaying by MediaState.isPlaying.collectAsState()
     val progress by MediaState.currentProgress.collectAsState()
@@ -94,6 +95,29 @@ fun MediaScreen(modifier: Modifier = Modifier) {
     var scrubPosition by remember { mutableStateOf<Long?>(null) }
     val displayProgress = scrubPosition ?: localProgress
     val colors = LocalAppColors.current
+
+    if (!hasActiveMedia) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(colors.appBackground),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.media_no_media),
+                style = MaterialTheme.typography.headlineSmall,
+                color = colors.onSurface,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.media_no_media_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colors.onSurfaceSecondary,
+            )
+        }
+        return
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/stormpanda/megingiard/media/MegingiardNotificationListener.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/media/MegingiardNotificationListener.kt
@@ -27,10 +27,14 @@ object MediaState {
     // Internal write access only for the NotificationListener
     internal var activeController: MediaController? = null
 
+    private val _hasActiveMedia = MutableStateFlow(false)
+    val hasActiveMedia: StateFlow<Boolean> = _hasActiveMedia.asStateFlow()
+
     internal fun updateTitle(title: String) { _currentTitle.value = title }
     internal fun updatePlaying(playing: Boolean) { _isPlaying.value = playing }
     internal fun updateProgress(progress: Long) { _currentProgress.value = progress }
     internal fun updateMaxProgress(max: Long) { _maxProgress.value = max }
+    internal fun updateHasActiveMedia(has: Boolean) { _hasActiveMedia.value = has }
 }
 
 // Read-only accessor for UI layers to issue transport commands
@@ -86,6 +90,7 @@ class MegingiardNotificationListener : NotificationListenerService() {
     private fun updateActiveSession(controller: MediaController?) {
         MediaState.activeController?.unregisterCallback(callback)
         MediaState.activeController = controller
+        MediaState.updateHasActiveMedia(controller != null)
         controller?.registerCallback(callback)
         callback.onMetadataChanged(controller?.metadata)
         callback.onPlaybackStateChanged(controller?.playbackState)

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
@@ -46,6 +46,20 @@ import java.util.Locale
 import kotlin.math.roundToInt
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+private val GS_TOOL_ROW_PADDING = 4.dp
+private const val GS_TIMEOUT_SLIDER_MIN_MS = 1000f
+private const val GS_TIMEOUT_SLIDER_MAX_MS = 15000f
+private const val GS_TIMEOUT_SNAP_MIN_S = 1L
+private const val GS_TIMEOUT_SNAP_MAX_S = 15L
+private val GS_DROPDOWN_ICON_SIZE = 20.dp
+private val GS_COLOR_PREVIEW_SIZE = 28.dp
+private val GS_COLOR_ICON_SPACER = 8.dp
+private val GS_ACCENT_ARROW_SIZE = 16.dp
+private val GS_DIVIDER_START_INSET = 56.dp
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Global settings UI components
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -82,7 +96,7 @@ internal fun ToolOrderRow(
         modifier = Modifier
             .fillMaxWidth()
             .background(if (isDragging) colors.surfaceVariant else colors.surface)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
+            .padding(horizontal = GS_TOOL_ROW_PADDING, vertical = GS_TOOL_ROW_PADDING),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
@@ -139,10 +153,10 @@ internal fun OverlayTimeoutRow(
             value = sliderValue,
             onValueChange = { sliderValue = it },
             onValueChangeFinished = {
-                val snapped = (sliderValue / 1000f).roundToInt().toLong().coerceIn(1L, 15L) * 1000L
+                val snapped = (sliderValue / 1000f).roundToInt().toLong().coerceIn(GS_TIMEOUT_SNAP_MIN_S, GS_TIMEOUT_SNAP_MAX_S) * 1000L
                 onTimeoutChanged(snapped)
             },
-            valueRange = 1000f..15000f,
+            valueRange = GS_TIMEOUT_SLIDER_MIN_MS..GS_TIMEOUT_SLIDER_MAX_MS,
             colors = SliderDefaults.colors(
                 thumbColor = accentColor,
                 activeTrackColor = accentColor
@@ -260,7 +274,7 @@ internal fun ThemePickerRow(
                 imageVector = Icons.Filled.ArrowDropDown,
                 contentDescription = null,
                 tint = colors.onSurfaceSecondary,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(GS_DROPDOWN_ICON_SIZE)
             )
             DropdownMenu(
                 expanded = expanded,
@@ -309,17 +323,83 @@ internal fun AccentColorRow(
         )
         Box(
             modifier = Modifier
-                .size(28.dp)
+                .size(GS_COLOR_PREVIEW_SIZE)
                 .clip(CircleShape)
                 .background(accentColor)
                 .border(1.dp, colors.accentBorder, CircleShape)
         )
-        Spacer(modifier = Modifier.size(8.dp))
+        Spacer(modifier = Modifier.size(GS_COLOR_ICON_SPACER))
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowForward,
             contentDescription = null,
             tint = colors.onSurfaceSecondary,
-            modifier = Modifier.size(16.dp)
+            modifier = Modifier.size(GS_ACCENT_ARROW_SIZE)
         )
+    }
+}
+
+internal fun AppLanguage.displayNameResId(): Int = when (this) {
+    AppLanguage.SYSTEM -> R.string.settings_language_system
+    AppLanguage.EN     -> R.string.settings_language_en
+    AppLanguage.DE     -> R.string.settings_language_de
+}
+
+@Composable
+internal fun LanguagePickerRow(
+    language: AppLanguage,
+    accentColor: Color,
+    colors: AppColors,
+    onChanged: (AppLanguage) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colors.surface)
+            .clickable { expanded = true }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.settings_language),
+                color = colors.onSurface,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = stringResource(language.displayNameResId()),
+                color = accentColor,
+                fontSize = 12.sp,
+            )
+        }
+        Box {
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                tint = colors.onSurfaceSecondary,
+                modifier = Modifier.size(GS_DROPDOWN_ICON_SIZE)
+            )
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.background(colors.surface)
+            ) {
+                AppLanguage.entries.forEach { option ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(option.displayNameResId()),
+                                color = if (option == language) accentColor else colors.onSurface,
+                                fontSize = 14.sp,
+                            )
+                        },
+                        onClick = {
+                            expanded = false
+                            if (option != language) onChanged(option)
+                        }
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
@@ -45,6 +45,7 @@ fun GlobalSettingsScreen(onBack: () -> Unit) {
     val overlayAtBottom by SettingsManager.overlayAtBottom.collectAsState()
     val rememberLastTool by SettingsManager.rememberLastTool.collectAsState()
     val themeMode by SettingsManager.themeMode.collectAsState()
+    val appLanguage by SettingsManager.appLanguage.collectAsState()
     val colors = LocalAppColors.current
     val effectiveAccent = colors.accent
 
@@ -160,6 +161,13 @@ fun GlobalSettingsScreen(onBack: () -> Unit) {
                         accentColor = effectiveAccent,
                         colors = colors,
                         onChanged = { SettingsManager.setRememberLastTool(it) }
+                    )
+                    HorizontalDivider(color = colors.divider)
+                    LanguagePickerRow(
+                        language = appLanguage,
+                        accentColor = effectiveAccent,
+                        colors = colors,
+                        onChanged = { SettingsManager.setAppLanguage(it) }
                     )
                     HorizontalDivider(color = colors.divider)
                 }

--- a/app/src/main/java/com/stormpanda/megingiard/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/SettingsManager.kt
@@ -43,6 +43,9 @@ import kotlinx.serialization.json.Json
 private const val SETTINGS_DATASTORE_NAME = "megingiard_settings"
 private const val DEFAULT_OVERLAY_TIMEOUT_MS = 3_000L
 
+/** Per-app language preference. [SYSTEM] follows the device locale. */
+enum class AppLanguage { SYSTEM, EN, DE }
+
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
     name = SETTINGS_DATASTORE_NAME
 )
@@ -84,6 +87,9 @@ object SettingsManager {
     private val KEY_KB_FULLSCREEN = booleanPreferencesKey("kb_fullscreen")
     private val KEY_KB_MOUSE_BTN_POS = stringPreferencesKey("kb_mouse_btn_pos")
 
+    // Language
+    private val KEY_APP_LANGUAGE = stringPreferencesKey("app_language")
+
     // Touchpad settings
     private val KEY_TOUCHPAD_USE_MOUSE = booleanPreferencesKey("touchpad_use_mouse")
     private val KEY_TOUCHPAD_TAP_TO_CLICK = booleanPreferencesKey("touchpad_tap_to_click")
@@ -92,6 +98,8 @@ object SettingsManager {
     private val KEY_SAVED_LOCKED = booleanPreferencesKey("mirror_saved_locked")
     private val KEY_SAVED_PROJECTION = booleanPreferencesKey("mirror_saved_projection")
 
+    // App-lifetime scope: intentionally never cancelled — this singleton lives for the
+    // duration of the process. Cancellation is handled by process termination.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var dataStore: DataStore<Preferences>
     private var initialized = false
@@ -170,6 +178,10 @@ object SettingsManager {
     private val _rememberLastTool = MutableStateFlow(false)
     val rememberLastTool: StateFlow<Boolean> = _rememberLastTool.asStateFlow()
 
+    // App language
+    private val _appLanguage = MutableStateFlow(AppLanguage.SYSTEM)
+    val appLanguage: StateFlow<AppLanguage> = _appLanguage.asStateFlow()
+
     fun init(context: Context) {
         if (initialized) return
         initialized = true
@@ -214,6 +226,7 @@ object SettingsManager {
                 _touchpadUseMouse.value = prefs[KEY_TOUCHPAD_USE_MOUSE] ?: false
                 _touchpadTapToClick.value = prefs[KEY_TOUCHPAD_TAP_TO_CLICK] ?: true
                 _touchpadTwoFingerTap.value = prefs[KEY_TOUCHPAD_TWO_FINGER_TAP] ?: true
+                _appLanguage.value = AppLanguage.entries.firstOrNull { it.name == prefs[KEY_APP_LANGUAGE] } ?: AppLanguage.SYSTEM
 
                 // MacroPad profiles
                 val macropadProfilesJson = prefs[KEY_MACROPAD_PROFILES]
@@ -360,6 +373,11 @@ object SettingsManager {
         scope.launch {
             dataStore.edit { prefs -> prefs[KEY_REMEMBER_LAST_TOOL] = value }
         }
+    }
+
+    fun setAppLanguage(value: AppLanguage) {
+        _appLanguage.value = value
+        scope.launch { dataStore.edit { prefs -> prefs[KEY_APP_LANGUAGE] = value.name } }
     }
 
     fun setKbLayout(value: KbLayout) {

--- a/app/src/main/java/com/stormpanda/megingiard/settings/ToolSettingsComponents.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/ToolSettingsComponents.kt
@@ -35,6 +35,14 @@ import com.stormpanda.megingiard.keyboard.KbMouseBtnPos
 import com.stormpanda.megingiard.ui.LocalAppColors
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+private const val TS_DROPDOWN_BG_ALPHA = 0.08f
+private val TS_DROPDOWN_H_PADDING = 12.dp
+private val TS_DROPDOWN_V_PADDING = 6.dp
+private val TS_DROPDOWN_CORNER = 8.dp
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Reusable setting row components
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -103,8 +111,8 @@ internal fun LayoutDropdownRow(
             Row(
                 modifier = Modifier
                     .clickable { expanded = true }
-                    .background(colors.onSurface.copy(alpha = 0.08f), RoundedCornerShape(8.dp))
-                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                    .background(colors.onSurface.copy(alpha = TS_DROPDOWN_BG_ALPHA), RoundedCornerShape(TS_DROPDOWN_CORNER))
+                    .padding(horizontal = TS_DROPDOWN_H_PADDING, vertical = TS_DROPDOWN_V_PADDING),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
@@ -168,8 +176,8 @@ internal fun MouseBtnPosDropdownRow(
             Row(
                 modifier = Modifier
                     .clickable { expanded = true }
-                    .background(colors.onSurface.copy(alpha = 0.08f), RoundedCornerShape(8.dp))
-                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                    .background(colors.onSurface.copy(alpha = TS_DROPDOWN_BG_ALPHA), RoundedCornerShape(TS_DROPDOWN_CORNER))
+                    .padding(horizontal = TS_DROPDOWN_H_PADDING, vertical = TS_DROPDOWN_V_PADDING),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(

--- a/app/src/main/java/com/stormpanda/megingiard/ui/CarouselOverlay.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/ui/CarouselOverlay.kt
@@ -79,8 +79,12 @@ private fun pillActiveWidth(toolCount: Int): Dp =
     CO_DOT_SPACING * (toolCount + 1) + CO_DOT_SIZE * toolCount
 
 // ── Settings button ────────────────────────────────────────────────────────
-private val CO_SETTINGS_BUTTON_SIZE = 40.dp
+private val CO_SETTINGS_BUTTON_SIZE = 48.dp  // Phase 6: increased from 40 to 48 dp (Material min touch target)
 private val CO_SETTINGS_ICON_SIZE = 20.dp
+private const val CO_DOT_INACTIVE_ALPHA = 0.35f
+private val CO_BORDER_WIDTH = 2.dp
+private val CO_HANDLE_CONTENT_H_PADDING = 12.dp
+private val CO_HANDLE_CONTENT_V_PADDING = 8.dp
 
 private fun AppMode.nameResId(): Int = when (this) {
     AppMode.MIRROR -> R.string.tool_name_mirror
@@ -206,8 +210,8 @@ private fun TopModeHandle(
                     .fillMaxWidth()
                     .padding(horizontal = CO_HANDLE_H_PADDING, vertical = CO_HANDLE_ROW_V_PADDING)
                     .background(colors.controlOverlay, RoundedCornerShape(CO_HANDLE_CORNER))
-                    .border(2.dp, colors.controlOverlayBorder, RoundedCornerShape(CO_HANDLE_CORNER))
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                        .border(CO_BORDER_WIDTH, colors.controlOverlayBorder, RoundedCornerShape(CO_HANDLE_CORNER))
+                        .padding(horizontal = CO_HANDLE_CONTENT_H_PADDING, vertical = CO_HANDLE_CONTENT_V_PADDING),
                 contentAlignment = Alignment.Center
             ) {
                 // Tool name – pinned to start
@@ -225,7 +229,7 @@ private fun TopModeHandle(
                     modifier = Modifier
                         .size(width = pillWidth, height = CO_PILL_ACTIVE_HEIGHT)
                         .background(colors.navPillBody, RoundedCornerShape(50))
-                        .border(2.dp, colors.navPillBorder, RoundedCornerShape(50))
+                        .border(CO_BORDER_WIDTH, colors.navPillBorder, RoundedCornerShape(50))
                         .pointerInput(activeTools) {
                             awaitEachGesture {
                                 var down = awaitPointerEvent()
@@ -285,7 +289,7 @@ private fun TopModeHandle(
                         activeTools.forEach { tool ->
                             val dotColor by animateColorAsState(
                                 targetValue = if (tool == currentMode) colors.controlIndicatorActive
-                                              else colors.onControlOverlay.copy(alpha = 0.35f),
+                                              else colors.onControlOverlay.copy(alpha = CO_DOT_INACTIVE_ALPHA),
                                 animationSpec = tween(durationMillis = CO_DOT_COLOR_ANIM_MS),
                                 label = "dot_color"
                             )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Megingiard</string>
+    <string name="mirror_waiting_permission">Warte auf Bildschirmberechtigung\u2026</string>
+    <string name="mirror_wrong_screen">Spiegelung wird nur unterstützt, wenn Megingiard auf dem unteren Bildschirm läuft.</string>
+    <string name="mirror_start_button">Spiegelung starten</string>
+    <string name="cd_previous_tool">Vorheriges Werkzeug</string>
+    <string name="cd_next_tool">Nächstes Werkzeug</string>
+    <string name="cd_stop_mirroring">Spiegelung stoppen</string>
+    <string name="cd_freeze">Einfrieren</string>
+    <string name="cd_unfreeze">Einfrieren aufheben</string>
+    <string name="cd_lock_view">Ansicht sperren</string>
+    <string name="cd_unlock_view">Ansicht entsperren</string>
+    <string name="cd_touch_projection_on">Touch-Projektion aktiv</string>
+    <string name="cd_touch_projection_off">Touch-Projektion inaktiv</string>
+    <string name="cd_frozen_image">Eingefrorenes Standbild</string>
+    <string name="media_no_media">Kein Medium</string>
+    <string name="media_unknown_title">Unbekannter Titel</string>
+    <string name="media_scrubbing_to">Spulen zu: %s</string>
+    <string name="notification_listener_required">Benachrichtigungszugriff für Mediensteuerung erforderlich</string>
+    <string name="grant_permission">Berechtigung erteilen</string>
+    <string name="notification_mirroring_active">Spiegelung aktiv</string>
+    <string name="cd_skip_previous">Vorheriger Titel</string>
+    <string name="cd_replay_10">10 Sekunden zurückspulen</string>
+    <string name="cd_play_pause">Wiedergabe / Pause</string>
+    <string name="cd_forward_10">10 Sekunden vorspulen</string>
+    <string name="cd_skip_next">Nächster Titel</string>
+    <string name="touchpad_hint">Hier tippen, um den oberen Bildschirm zu steuern</string>
+    <string name="touchpad_hint_mouse">Ziehen zum Bewegen · Tippen zum Klicken</string>
+
+    <!-- Tool display names -->
+    <string name="tool_name_mirror">Spiegel</string>
+    <string name="tool_name_media">Medien</string>
+    <string name="tool_name_touchpad">Touchpad</string>
+    <string name="tool_name_keyboard">Tastatur</string>
+    <string name="tool_name_macropad">MacroPad</string>
+    <string name="keyboard_placeholder">Tastatur kommt bald\u2026</string>
+    <string name="cd_keyboard_key">Taste %s</string>
+    <string name="cd_keyboard_trackpoint">Trackpoint</string>
+
+    <!-- Settings screen -->
+    <string name="settings_close">Schließen</string>
+    <string name="cd_open_settings">Einstellungen öffnen</string>
+    <string name="cd_open_global_settings">Globale Einstellungen öffnen</string>
+    <string name="cd_drag_reorder">Zum Sortieren ziehen</string>
+    <string name="settings_section_tools">Werkzeuge</string>
+    <string name="settings_section_general">Allgemein</string>
+    <string name="settings_section_appearance">Erscheinungsbild</string>
+    <string name="settings_auto_start_capture">Spiegelung automatisch starten</string>
+    <string name="settings_auto_start_capture_desc">Beim App-Start automatisch die Bildschirmaufnahme anfragen</string>
+    <string name="settings_overlay_timeout">Steuerung ausblenden nach: %ds</string>
+    <string name="settings_no_tool_settings">Keine Einstellungen für dieses Werkzeug verfügbar.</string>
+    <string name="settings_global_title">Einstellungen</string>
+    <string name="settings_back">Zurück</string>
+    <string name="settings_accent_color">Akzentfarbe</string>
+    <string name="settings_theme">Design</string>
+    <string name="theme_dark">Dunkel</string>
+    <string name="theme_light">Hell</string>
+    <string name="theme_cyberpunk">Cyberpunk</string>
+    <string name="settings_overlay_position">Steuerleiste unten platzieren</string>
+    <string name="settings_accent_color_picker_title">Akzentfarbe wählen</string>
+    <string name="settings_color_brightness">Helligkeit</string>
+    <string name="settings_color_cancel">Abbrechen</string>
+    <string name="settings_color_apply">Anwenden</string>
+
+    <!-- Keyboard settings -->
+    <string name="settings_kb_layout">Tastaturlayout</string>
+    <string name="settings_kb_layout_desc">Buchstabenanordnung</string>
+    <string name="settings_kb_layout_qwertz">QWERTZ</string>
+    <string name="settings_kb_layout_qwerty">QWERTY</string>
+    <string name="settings_kb_layout_azerty">AZERTY</string>
+    <string name="settings_kb_trackpoint">Trackpoint</string>
+    <string name="settings_kb_trackpoint_desc">Trackpoint-Punkt in der Grundreihe anzeigen</string>
+    <string name="settings_kb_repeat">Tastenwiederholung</string>
+    <string name="settings_kb_repeat_desc">Taste gedrückt halten für Wiederholung</string>
+    <string name="settings_kb_fullscreen">Vollbild-Tastatur</string>
+    <string name="settings_kb_fullscreen_desc">Kein Abstand unten — Tastatur füllt den gesamten Bildschirm</string>
+
+    <!-- Input method (touchpad + keyboard trackpoint) -->
+    <string name="settings_input_method">Mausmodus</string>
+    <string name="settings_input_method_desc">Mausbewegungen statt Touch-Steuerung</string>
+    <string name="settings_tap_to_click">Tippen zum Klicken</string>
+    <string name="settings_tap_to_click_desc">Einfaches Tippen = Linksklick</string>
+    <string name="settings_two_finger_tap">Zwei-Finger-Tippen</string>
+    <string name="settings_two_finger_tap_desc">Zwei-Finger-Tippen = Rechtsklick</string>
+
+    <!-- Mirror touch projection -->
+    <string name="settings_pinch_while_projecting">Pinch-to-Zoom während Projektion</string>
+    <string name="settings_pinch_while_projecting_desc">Zwei-Finger-Zoomen und Schwenken während die Touch-Projektion aktiv ist. Zwei-Finger-Gesten werden nicht an das primäre Display weitergeleitet.</string>
+
+    <!-- Mirror session state persistence -->
+    <string name="settings_remember_viewport">Ansichtsausschnitt merken</string>
+    <string name="settings_remember_viewport_desc">Zoom und Position beim Neustart der Spiegelung wiederherstellen</string>
+    <string name="settings_remember_lock">Sperre merken</string>
+    <string name="settings_remember_lock_desc">Gesperrten Zustand beim Neustart der Spiegelung wiederherstellen</string>
+    <string name="settings_remember_projection">Touch-Projektion merken</string>
+    <string name="settings_remember_projection_desc">Touch-Projektion-Status beim Neustart der Spiegelung wiederherstellen</string>
+
+    <!-- General session -->
+    <string name="settings_remember_last_tool">Letztes Werkzeug merken</string>
+    <string name="settings_remember_last_tool_desc">Aktives Werkzeug beim App-Neustart wiederherstellen</string>
+
+    <!-- MacroPad tool -->
+    <string name="macropad_no_profile">Kein Profil konfiguriert.
+Einstellungen öffnen, um ein Layout zu erstellen.</string>
+    <string name="macropad_open_settings">Einstellungen öffnen</string>
+    <string name="cd_macropad_button">MacroPad-Taste: %s</string>
+    <string name="cd_macropad_trackpoint">Trackpoint</string>
+
+    <!-- MacroPad editor -->
+    <string name="macropad_editor_title">Layout bearbeiten</string>
+    <string name="macropad_editor_done">Fertig</string>
+    <string name="macropad_editor_add_button">Taste hinzufügen</string>
+    <string name="macropad_editor_delete_button">Löschen</string>
+    <string name="macropad_editor_button_label">Beschriftung</string>
+    <string name="macropad_editor_action">Aktion</string>
+    <string name="macropad_editor_button_shape">Tastenform</string>
+    <string name="macropad_editor_shape_circle">Kreis</string>
+    <string name="macropad_editor_shape_square">Quadrat</string>
+    <string name="macropad_editor_button_size">Tastengröße</string>
+    <string name="macropad_button_size_1x1">1×1</string>
+    <string name="macropad_button_size_2x1">2×1</string>
+    <string name="macropad_button_size_1x2">1×2</string>
+    <string name="macropad_button_size_2x2">2×2</string>
+    <string name="macropad_editor_trackpoint_size">Trackpoint-Größe</string>
+    <string name="macropad_trackpoint_size_small">Klein</string>
+    <string name="macropad_trackpoint_size_medium">Mittel</string>
+    <string name="macropad_trackpoint_size_large">Groß</string>
+    <string name="macropad_editor_devices">Simulierte Geräte</string>
+    <string name="macropad_editor_device_keyboard">Tastatur</string>
+    <string name="macropad_editor_device_gamepad">Gamepad</string>
+    <string name="macropad_editor_device_mouse">Maus</string>
+    <string name="macropad_device_disabled_keyboard">Tastatur ist für dieses Layout deaktiviert</string>
+    <string name="macropad_device_disabled_gamepad">Gamepad ist für dieses Layout deaktiviert</string>
+
+    <!-- Keyboard trackpoint virtual mouse buttons -->
+    <string name="kb_mouse_btn_left">LMT</string>
+    <string name="kb_mouse_btn_middle">MMT</string>
+    <string name="kb_mouse_btn_right">RMT</string>
+    <string name="kb_mouse_btn_4">M4</string>
+    <string name="kb_mouse_btn_5">M5</string>
+    <!-- Keyboard trackpoint mouse button position setting -->
+    <string name="settings_kb_mouse_btn_pos">Tastenposition</string>
+    <string name="settings_kb_mouse_btn_pos_desc">Wo die LMT/RMT-Tasten erscheinen</string>
+    <string name="kb_mouse_btn_pos_left">Links</string>
+    <string name="kb_mouse_btn_pos_right">Rechts</string>
+    <string name="kb_mouse_btn_pos_both">Links &amp; Rechts</string>
+    <string name="macropad_device_disabled_mouse">Maus ist für dieses Layout deaktiviert</string>
+    <string name="macropad_editor_new_profile_name">Neues Profil</string>
+    <string name="macropad_editor_rename">Umbenennen</string>
+    <string name="macropad_editor_delete_profile">Profil löschen</string>
+    <string name="macropad_editor_confirm_delete">Dieses Profil löschen?</string>
+    <string name="macropad_editor_cancel">Abbrechen</string>
+    <string name="macropad_editor_confirm">Löschen</string>
+
+    <!-- MacroPad action picker labels -->
+    <string name="macropad_action_keyboard_key">Tastaturtaste</string>
+    <string name="macropad_action_gamepad_button">Gamepad-Taste</string>
+    <string name="macropad_action_mouse_button">Maustaste</string>
+    <string name="macropad_action_scroll_wheel">Scrollrad</string>
+    <string name="macropad_action_trackpoint">Trackpoint (relative Maus)</string>
+
+    <!-- MacroPad settings (ToolSettingsPanel) -->
+    <string name="settings_macropad_profile">Aktives Profil</string>
+    <string name="settings_macropad_new_profile">Neues Profil\u2026</string>
+    <string name="settings_macropad_pad_shape">Pad-Form</string>
+    <string name="settings_macropad_shape_square">Quadrat</string>
+    <string name="settings_macropad_shape_circle">Kreis</string>
+    <string name="settings_macropad_pad_size">Pad-Größe: %d%%</string>
+    <string name="settings_macropad_edit_layout">Layout bearbeiten\u2026</string>
+    <string name="settings_macropad_new_layout">Neues Layout</string>
+
+    <!-- MacroPad button action display labels (shown in editor button list) -->
+    <string name="macropad_display_keyboard_key">Taste: %s</string>
+    <string name="macropad_display_gamepad_button">Gamepad: %s</string>
+    <string name="macropad_display_mouse_button">Maus: %s</string>
+    <string name="macropad_display_scroll_wheel">Scrollrad</string>
+    <string name="macropad_display_trackpoint">Trackpoint</string>
+
+    <!-- Language setting -->
+    <string name="settings_language">Sprache</string>
+    <string name="settings_language_system">Systemstandard</string>
+    <string name="settings_language_en">English</string>
+    <string name="settings_language_de">Deutsch</string>
+
+    <!-- Exit confirmation dialog -->
+    <string name="exit_dialog_title">Megingiard beenden</string>
+    <string name="exit_dialog_message">Möchtest du die App schließen?</string>
+    <string name="exit_dialog_confirm">Schließen</string>
+    <string name="exit_dialog_cancel">Abbrechen</string>
+
+    <!-- Media empty state -->
+    <string name="media_no_media_hint">Starte eine Medienwiedergabe auf dem oberen Bildschirm, um sie hier zu steuern.</string>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,16 +1,6 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.Megingiard" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+<resources>
+    <!-- Night-mode override — no additional items needed; theming is code-driven via AppColors. -->
+    <style name="Theme.Megingiard" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <!-- App-level utility colors. All UI theming is handled by AppColors / AppTheme in Kotlin. -->
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,11 +139,11 @@ Open Settings to create a layout.</string>
     <string name="kb_mouse_btn_4">M4</string>
     <string name="kb_mouse_btn_5">M5</string>
     <!-- Keyboard trackpoint mouse button position setting -->
-    <string name="settings_kb_mouse_btn_pos">Button-Position</string>
-    <string name="settings_kb_mouse_btn_pos_desc">Wo die LMB/RMB-Tasten erscheinen</string>
-    <string name="kb_mouse_btn_pos_left">Links</string>
-    <string name="kb_mouse_btn_pos_right">Rechts</string>
-    <string name="kb_mouse_btn_pos_both">Links &amp; Rechts</string>
+    <string name="settings_kb_mouse_btn_pos">Button Position</string>
+    <string name="settings_kb_mouse_btn_pos_desc">Where the LMB/RMB buttons appear</string>
+    <string name="kb_mouse_btn_pos_left">Left</string>
+    <string name="kb_mouse_btn_pos_right">Right</string>
+    <string name="kb_mouse_btn_pos_both">Left &amp; Right</string>
     <string name="macropad_device_disabled_mouse">Mouse has been disabled for this layout</string>
     <string name="macropad_editor_new_profile_name">New Profile</string>
     <string name="macropad_editor_rename">Rename</string>
@@ -175,4 +175,19 @@ Open Settings to create a layout.</string>
     <string name="macropad_display_mouse_button">Mouse: %s</string>
     <string name="macropad_display_scroll_wheel">Scroll Wheel</string>
     <string name="macropad_display_trackpoint">Trackpoint</string>
+
+    <!-- Language setting -->
+    <string name="settings_language">Language</string>
+    <string name="settings_language_system">System default</string>
+    <string name="settings_language_en">English</string>
+    <string name="settings_language_de">Deutsch</string>
+
+    <!-- Exit confirmation dialog -->
+    <string name="exit_dialog_title">Exit Megingiard</string>
+    <string name="exit_dialog_message">Do you want to close the app?</string>
+    <string name="exit_dialog_confirm">Close</string>
+    <string name="exit_dialog_cancel">Cancel</string>
+
+    <!-- Media empty state -->
+    <string name="media_no_media_hint">Start media playback on the top screen to control it here.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,16 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.Megingiard" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <!-- Base application theme. The per-Activity themes (Theme.DeviceDefault.NoActionBar
+         and Theme.Translucent.NoTitleBar) override this for all visible components.
+         This style only affects non-Activity system windows. -->
+    <style name="Theme.Megingiard" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="de"/>
+</locale-config>

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -8,6 +8,7 @@ Detailed functional requirements (including acceptance criteria and edge cases) 
 | Media Control    | Transport controls, scrubbing, progress tracking                                                   | [docs/features/media/FEATURE.md](features/media/FEATURE.md)       |
 | Virtual Touchpad | Native touch injection, coordinate mapping, visual feedback                                        | [docs/features/touchpad/FEATURE.md](features/touchpad/FEATURE.md) |
 | Virtual Keyboard | Full keyboard layout (QWERTZ/QWERTY/AZERTY), modifier key state machine, trackpoint, key injection | [docs/features/keyboard/FEATURE.md](features/keyboard/FEATURE.md) |
+| MacroPad         | Configurable button pad, multiple named profiles, free-placement buttons, action types (keyboard key, gamepad button, mouse click, scroll wheel, trackpoint) | [docs/features/macropad/FEATURE.md](features/macropad/FEATURE.md) |
 
 ---
 


### PR DESCRIPTION
- extract all magic numbers to named constants in GlobalSettingsComponents, ToolSettingsComponents, CarouselOverlay; bump settings button to 48dp (Material min touch target)
- fix ShellKeyInjector executor leak: shutdownNow() in finally block
- add app-lifetime scope comments to AppStateManager, SettingsManager, MacroPadState
- migrate values/themes.xml and values-night/themes.xml to Theme.Material3.DayNight.NoActionBar; remove all Material 2 color references (colorPrimary, colorSecondary, etc.)
- remove dead Material 2 color resources from colors.xml (purple_200/500/700, teal_200/700)
- add MacroPad section to PRD.md §2.5, REQUIREMENTS.md feature table, README.md feature list
- expand AndroidManifest configChanges (orientation, screenSize, screenLayout, smallestScreenSize); add android:localeConfig="@xml/locales_config"
- normalize 5 German strings in root strings.xml to English; add language picker, exit dialog, and media empty-state hint strings
- create values-de/strings.xml with full German translation (~226 strings)
- create res/xml/locales_config.xml with en + de locale declarations
- add AppLanguage enum (SYSTEM/EN/DE), appLanguage StateFlow and DataStore persistence to SettingsManager
- add LanguagePickerRow composable with dropdown to GlobalSettingsComponents; wire into GlobalSettingsScreen General section
- apply locale change via LocaleManager.setApplicationLocales() in MainActivity on language setting change
- add hasActiveMedia StateFlow to MediaState; show empty-state UI (title + hint text) in MediaScreen when no active media controller
- add BackHandler + AlertDialog exit confirmation dialog in MainAppScreen
- wrap keyboard layout Column in Crossfade for smooth animation on layout switch (QWERTZ/QWERTY/AZERTY) in KeyboardScreen