### PR TITLE
feat: add macro folder organisation to MacroPad

### DIFF
--- a/app/src/main/java/com/stormpanda/megingiard/macropad/MacroData.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/MacroData.kt
@@ -85,13 +85,33 @@ sealed class MacroStep {
 fun List<MacroStep>.totalDurationMs(): Long = maxOfOrNull { it.endTimeMs() } ?: 0L
 
 // ─────────────────────────────────────────────────────────────────────────────
+// MacroFolder — a named group for organising macros
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @param id   Stable unique identifier (UUID string).
+ * @param name User-visible folder name.
+ *
+ * Macros without a [Macro.folderId] (or with [folderId] = null) belong to the implicit
+ * "Unassigned" group and are never stored inside a folder object.
+ */
+@Serializable
+data class MacroFolder(
+    val id: String,
+    val name: String,
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Macro — a named sequence of timed steps
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * @param id    Stable unique identifier (UUID string).
- * @param name  User-visible name shown in editors and on pad buttons.
- * @param steps Ordered list of timed steps; steps may overlap for parallel execution.
+ * @param id       Stable unique identifier (UUID string).
+ * @param name     User-visible name shown in editors and on pad buttons.
+ * @param folderId Optional reference to a [MacroFolder.id]. `null` means the macro is
+ *                 in the implicit "Unassigned" section. Defaults to `null` so that
+ *                 existing saved JSON without this field is deserialized correctly.
+ * @param steps    Ordered list of timed steps; steps may overlap for parallel execution.
  *
  * The data is exported/imported as a standalone JSON array via [kotlinx.serialization].
  */
@@ -99,5 +119,6 @@ fun List<MacroStep>.totalDurationMs(): Long = maxOfOrNull { it.endTimeMs() } ?: 
 data class Macro(
     val id: String,
     val name: String,
+    val folderId: String? = null,
     val steps: List<MacroStep> = emptyList(),
 )

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/MacroListEditor.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/MacroListEditor.kt
@@ -3,7 +3,6 @@ package com.stormpanda.megingiard.macropad
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,26 +14,37 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CreateNewFolder
 import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,7 +52,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,8 +65,37 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-private const val ML_TOP_BAR_HEIGHT = 56
-private const val ML_PADDING        = 16
+private const val ML_TOP_BAR_HEIGHT  = 56
+private const val ML_PADDING         = 16
+private const val ML_HEADER_HEIGHT   = 48
+private const val ML_SECTION_INDENT  = ML_PADDING + 44   // indent for "New Macro" chips
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flat list item types (used to build a single LazyColumn across all sections)
+// ─────────────────────────────────────────────────────────────────────────────
+
+private sealed class MacroListItem {
+    abstract val key: String
+
+    data class SectionHeader(
+        val folderId: String?,
+        val name: String,
+        val folderIndex: Int,       // −1 for "Unassigned"
+    ) : MacroListItem() {
+        override val key get() = "hdr_${folderId ?: "none"}"
+    }
+
+    data class MacroEntry(
+        val macro: Macro,
+        val sectionFolderId: String?,
+    ) : MacroListItem() {
+        override val key get() = "macro_${macro.id}"
+    }
+
+    data class NewMacroButton(val folderId: String?) : MacroListItem() {
+        override val key get() = "newbtn_${folderId ?: "none"}"
+    }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MacroListEditor — navigation host (no self-wrapping Dialog)
@@ -67,7 +105,7 @@ private const val ML_PADDING        = 16
  * Full-screen macro library editor.
  *
  * Hosts two views via internal navigation:
- * - **[MacroListView]** — lists all global macros with create and delete actions.
+ * - **[MacroListView]** — lists all global macros organised in folder sections.
  * - **[MacroTimelineEditor]** — step editor for a single macro.
  *
  * The caller is responsible for wrapping this in a `Dialog(usePlatformDefaultWidth = false)`.
@@ -76,36 +114,30 @@ private const val ML_PADDING        = 16
  */
 @Composable
 internal fun MacroListEditor(onDone: () -> Unit) {
-    val colors      = LocalAppColors.current
-    val accentColor = colors.accent
-    var editingMacro by remember { mutableStateOf<Macro?>(null) }
-    val defaultName  = stringResource(R.string.macropad_macro_default_name)
+    val colors         = LocalAppColors.current
+    val accentColor    = colors.accent
+    var editingMacro   by remember { mutableStateOf<Macro?>(null) }
+    var newMacroFolder by remember { mutableStateOf<String?>(null) }
+    val defaultName    = stringResource(R.string.macropad_macro_default_name)
     val copyNameFormat = stringResource(R.string.macropad_macro_copy_name)
 
     if (editingMacro == null) {
         MacroListView(
-            accentColor  = accentColor,
-            onEditMacro  = { editingMacro = it },
+            accentColor      = accentColor,
+            onEditMacro      = { editingMacro = it },
             onDuplicateMacro = { original ->
                 val existingNames = MacroState.macros.value.map { it.name }.toSet()
                 val baseName = copyNameFormat.format(original.name)
-                val copyName = if (baseName !in existingNames) {
-                    baseName
-                } else {
+                val copyName = if (baseName !in existingNames) baseName else {
                     var n = 2
                     while ("$baseName ($n)" in existingNames) n++
                     "$baseName ($n)"
                 }
-                MacroState.addMacro(
-                    original.copy(id = UUID.randomUUID().toString(), name = copyName)
-                )
+                MacroState.addMacro(original.copy(id = UUID.randomUUID().toString(), name = copyName))
             },
-            onNewMacro  = {
-                editingMacro = Macro(
-                    id    = UUID.randomUUID().toString(),
-                    name  = defaultName,
-                    steps = emptyList(),
-                )
+            onNewMacro = { folderId ->
+                newMacroFolder = folderId
+                editingMacro   = Macro(id = UUID.randomUUID().toString(), name = defaultName, steps = emptyList())
             },
             onDone = onDone,
         )
@@ -115,16 +147,24 @@ internal fun MacroListEditor(onDone: () -> Unit) {
             accentColor = accentColor,
             onSave      = { saved ->
                 val isNew = MacroState.macros.value.none { it.id == saved.id }
-                if (isNew) MacroState.addMacro(saved) else MacroState.updateMacro(saved)
-                editingMacro = null
+                if (isNew) {
+                    MacroState.addMacro(saved.copy(folderId = newMacroFolder))
+                } else {
+                    MacroState.updateMacro(saved)
+                }
+                editingMacro   = null
+                newMacroFolder = null
             },
-            onBack      = { editingMacro = null },
+            onBack = {
+                editingMacro   = null
+                newMacroFolder = null
+            },
         )
     }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Macro list view
+// Macro list view — folder-sectioned list
 // ─────────────────────────────────────────────────────────────────────────────
 
 @Composable
@@ -132,19 +172,64 @@ private fun MacroListView(
     accentColor:      Color,
     onEditMacro:      (Macro) -> Unit,
     onDuplicateMacro: (Macro) -> Unit,
-    onNewMacro:       () -> Unit,
+    onNewMacro:       (folderId: String?) -> Unit,
     onDone:           () -> Unit,
 ) {
-    val macros   by MacroState.macros.collectAsState()
-    val colors   = LocalAppColors.current
-    var deletingId by remember { mutableStateOf<String?>(null) }
+    val macros         by MacroState.macros.collectAsState()
+    val folders        by MacroState.folders.collectAsState()
+    val colors         = LocalAppColors.current
+    val unassignedLabel = stringResource(R.string.macro_folder_unassigned)
 
-    val lazyListState = rememberLazyListState()
-    val reorderState  = rememberReorderableLazyListState(lazyListState) { from, to ->
-        val newMacros  = macros.toMutableList()
-        val safeToIdx  = to.index.coerceIn(0, newMacros.lastIndex)
-        newMacros.add(safeToIdx, newMacros.removeAt(from.index))
-        MacroState.reorderMacros(newMacros)
+    // Section expand/collapse: null key = "Unassigned"; absent = expanded
+    val expandedSections = remember { mutableStateMapOf<String?, Boolean>() }
+
+    // Dialog state
+    var deletingMacroId   by remember { mutableStateOf<String?>(null) }
+    var movingMacroId     by remember { mutableStateOf<String?>(null) }
+    var renamingFolderId  by remember { mutableStateOf<String?>(null) }
+    var deletingFolderId  by remember { mutableStateOf<String?>(null) }
+    var showNewFolder     by remember { mutableStateOf(false) }
+
+    // Flat item list derived from current state
+    val flatList by remember {
+        derivedStateOf {
+            buildList {
+                val unassignedExpanded = expandedSections[null] != false
+                add(MacroListItem.SectionHeader(folderId = null, name = unassignedLabel, folderIndex = -1))
+                if (unassignedExpanded) {
+                    macros.filter { it.folderId == null }.forEach { add(MacroListItem.MacroEntry(it, null)) }
+                    add(MacroListItem.NewMacroButton(null))
+                }
+                folders.forEachIndexed { idx, folder ->
+                    val isExpanded = expandedSections[folder.id] != false
+                    add(MacroListItem.SectionHeader(folderId = folder.id, name = folder.name, folderIndex = idx))
+                    if (isExpanded) {
+                        macros.filter { it.folderId == folder.id }.forEach { add(MacroListItem.MacroEntry(it, folder.id)) }
+                        add(MacroListItem.NewMacroButton(folder.id))
+                    }
+                }
+            }
+        }
+    }
+
+    val lazyListState    = rememberLazyListState()
+    val latestFlatList   by rememberUpdatedState(flatList)
+
+    // Only reorder macros within the same section; cross-section drags are no-ops
+    val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val fromItem = latestFlatList.firstOrNull { it.key == from.key as? String }
+        val toItem   = latestFlatList.firstOrNull { it.key == to.key as? String }
+        if (fromItem is MacroListItem.MacroEntry && toItem is MacroListItem.MacroEntry
+            && fromItem.sectionFolderId == toItem.sectionFolderId
+        ) {
+            val section = macros.filter { it.folderId == fromItem.sectionFolderId }.toMutableList()
+            val fromIdx = section.indexOfFirst { it.id == fromItem.macro.id }
+            val toIdx   = section.indexOfFirst { it.id == toItem.macro.id }
+            if (fromIdx >= 0 && toIdx >= 0) {
+                section.add(toIdx, section.removeAt(fromIdx))
+                MacroState.reorderMacrosInFolder(fromItem.sectionFolderId, section)
+            }
+        }
     }
 
     Column(
@@ -152,7 +237,7 @@ private fun MacroListView(
             .fillMaxSize()
             .background(colors.appBackground),
     ) {
-        // Top bar
+        // ── Top bar ──────────────────────────────────────────────────────────
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -168,6 +253,13 @@ private fun MacroListView(
                 fontWeight = FontWeight.SemiBold,
                 modifier   = Modifier.weight(1f),
             )
+            IconButton(onClick = { showNewFolder = true }) {
+                Icon(
+                    Icons.Filled.CreateNewFolder,
+                    contentDescription = stringResource(R.string.macro_folder_new),
+                    tint               = accentColor,
+                )
+            }
             TextButton(onClick = onDone) {
                 Text(
                     stringResource(R.string.macropad_editor_done),
@@ -179,85 +271,81 @@ private fun MacroListView(
 
         HorizontalDivider(color = colors.divider)
 
+        // ── Sectioned list ───────────────────────────────────────────────────
         LazyColumn(
             state    = lazyListState,
             modifier = Modifier.fillMaxSize(),
         ) {
-            if (macros.isEmpty()) {
-                item(key = "empty") {
-                    Text(
-                        stringResource(R.string.macropad_macro_list_empty),
-                        color     = colors.onSurfaceSecondary,
-                        textAlign = TextAlign.Center,
-                        fontSize  = 13.sp,
-                        modifier  = Modifier
-                            .fillMaxWidth()
-                            .padding(32.dp),
-                    )
-                }
-            }
-
-            itemsIndexed(macros, key = { _, m -> m.id }) { _, macro ->
-                ReorderableItem(reorderState, key = macro.id) { isDragging ->
-                    MacroRow(
-                        macro              = macro,
-                        accentColor        = accentColor,
-                        isDragging         = isDragging,
-                        onEdit             = { onEditMacro(macro) },
-                        onDuplicate        = { onDuplicateMacro(macro) },
-                        onDelete           = { deletingId = macro.id },
-                        dragHandleModifier = Modifier.draggableHandle(),
-                    )
-                    HorizontalDivider(color = colors.divider)
-                }
-            }
-
-            // New Macro chip
-            item(key = "new_macro") {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = ML_PADDING.dp, vertical = 12.dp),
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(8.dp))
-                            .border(1.dp, accentColor.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
-                            .clickable(onClick = onNewMacro)
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
-                        verticalAlignment     = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        Icon(
-                            Icons.Filled.Add,
-                            contentDescription = null,
-                            tint     = accentColor,
-                            modifier = Modifier.size(18.dp),
+            items(flatList, key = { it.key }) { item ->
+                when (item) {
+                    is MacroListItem.SectionHeader -> {
+                        FolderSectionHeader(
+                            folderId      = item.folderId,
+                            name          = item.name,
+                            folderIndex   = item.folderIndex,
+                            foldersCount  = folders.size,
+                            isExpanded    = expandedSections[item.folderId] != false,
+                            accentColor   = accentColor,
+                            onToggleExpand = {
+                                expandedSections[item.folderId] = expandedSections[item.folderId] == false
+                            },
+                            onRename  = { renamingFolderId = item.folderId },
+                            onDelete  = { deletingFolderId = item.folderId },
+                            onMoveUp  = {
+                                val idx = item.folderIndex
+                                if (idx > 0) {
+                                    val mutable = folders.toMutableList()
+                                    mutable.add(idx - 1, mutable.removeAt(idx))
+                                    MacroState.reorderFolders(mutable)
+                                }
+                            },
+                            onMoveDown = {
+                                val idx = item.folderIndex
+                                if (idx in 0 until folders.lastIndex) {
+                                    val mutable = folders.toMutableList()
+                                    mutable.add(idx + 1, mutable.removeAt(idx))
+                                    MacroState.reorderFolders(mutable)
+                                }
+                            },
                         )
-                        Spacer(Modifier.width(6.dp))
-                        Text(
-                            stringResource(R.string.macropad_macro_list_new),
-                            color    = accentColor,
-                            fontSize = 13.sp,
-                        )
+                        HorizontalDivider(color = colors.divider)
+                    }
+
+                    is MacroListItem.MacroEntry -> {
+                        ReorderableItem(reorderState, key = item.key) { isDragging ->
+                            MacroRow(
+                                macro              = item.macro,
+                                accentColor        = accentColor,
+                                isDragging         = isDragging,
+                                onEdit             = { onEditMacro(item.macro) },
+                                onDuplicate        = { onDuplicateMacro(item.macro) },
+                                onMoveToFolder     = { movingMacroId = item.macro.id },
+                                onDelete           = { deletingMacroId = item.macro.id },
+                                dragHandleModifier = Modifier.draggableHandle(),
+                            )
+                            HorizontalDivider(color = colors.divider)
+                        }
+                    }
+
+                    is MacroListItem.NewMacroButton -> {
+                        NewMacroChip(accentColor = accentColor, onClick = { onNewMacro(item.folderId) })
                     }
                 }
             }
         }
     }
 
-    // Delete confirmation dialog
-    if (deletingId != null) {
-        val macroId  = deletingId!!
+    // ── Dialogs ──────────────────────────────────────────────────────────────
+
+    if (deletingMacroId != null) {
+        val macroId  = deletingMacroId!!
         val refCount = MacroPadState.profiles.value
             .sumOf { p -> p.buttons.count { b -> (b.action as? PadAction.Macro)?.macroId == macroId } }
         AlertDialog(
             containerColor   = colors.surface,
-            onDismissRequest = { deletingId = null },
-            title = {
-                Text(stringResource(R.string.macropad_macro_delete_title), color = colors.onSurface)
-            },
-            text = {
+            onDismissRequest = { deletingMacroId = null },
+            title   = { Text(stringResource(R.string.macropad_macro_delete_title), color = colors.onSurface) },
+            text    = {
                 Text(
                     if (refCount > 0)
                         stringResource(R.string.macropad_macro_delete_confirm_referenced, refCount)
@@ -267,24 +355,175 @@ private fun MacroListView(
                 )
             },
             confirmButton = {
-                TextButton(onClick = {
-                    MacroState.deleteMacro(macroId)
-                    deletingId = null
-                }) {
+                TextButton(onClick = { MacroState.deleteMacro(macroId); deletingMacroId = null }) {
                     Text(stringResource(R.string.macropad_editor_confirm), color = Color(0xFFCF6679))
                 }
             },
             dismissButton = {
-                TextButton(onClick = { deletingId = null }) {
+                TextButton(onClick = { deletingMacroId = null }) {
                     Text(stringResource(R.string.macropad_editor_cancel), color = colors.onSurfaceSecondary)
                 }
             },
         )
     }
+
+    if (movingMacroId != null) {
+        val macroId        = movingMacroId!!
+        val currentFolderId = macros.firstOrNull { it.id == macroId }?.folderId
+        FolderPickerDialog(
+            title            = stringResource(R.string.macro_folder_move_title),
+            folders          = folders,
+            selectedFolderId = currentFolderId,
+            unassignedLabel  = unassignedLabel,
+            accentColor      = accentColor,
+            onSelect         = { fId -> MacroState.moveMacroToFolder(macroId, fId); movingMacroId = null },
+            onDismiss        = { movingMacroId = null },
+        )
+    }
+
+    if (renamingFolderId != null) {
+        val fId         = renamingFolderId!!
+        val currentName = folders.firstOrNull { it.id == fId }?.name ?: ""
+        TextInputDialog(
+            title       = stringResource(R.string.macro_folder_rename),
+            hint        = stringResource(R.string.macro_folder_name_hint),
+            initialValue = currentName,
+            accentColor = accentColor,
+            onConfirm   = { name ->
+                if (name.isNotBlank()) MacroState.renameFolder(fId, name.trim())
+                renamingFolderId = null
+            },
+            onDismiss   = { renamingFolderId = null },
+        )
+    }
+
+    if (deletingFolderId != null) {
+        val fId = deletingFolderId!!
+        AlertDialog(
+            containerColor   = colors.surface,
+            onDismissRequest = { deletingFolderId = null },
+            title   = { Text(stringResource(R.string.macro_folder_delete), color = colors.onSurface) },
+            text    = { Text(stringResource(R.string.macro_folder_delete_confirm), color = colors.onSurfaceSecondary) },
+            confirmButton = {
+                TextButton(onClick = { MacroState.deleteFolder(fId); deletingFolderId = null }) {
+                    Text(stringResource(R.string.macropad_editor_confirm), color = Color(0xFFCF6679))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deletingFolderId = null }) {
+                    Text(stringResource(R.string.macropad_editor_cancel), color = colors.onSurfaceSecondary)
+                }
+            },
+        )
+    }
+
+    if (showNewFolder) {
+        TextInputDialog(
+            title        = stringResource(R.string.macro_folder_new),
+            hint         = stringResource(R.string.macro_folder_name_hint),
+            initialValue = "",
+            accentColor  = accentColor,
+            onConfirm    = { name ->
+                if (name.isNotBlank()) {
+                    MacroState.addFolder(MacroFolder(id = UUID.randomUUID().toString(), name = name.trim()))
+                }
+                showNewFolder = false
+            },
+            onDismiss    = { showNewFolder = false },
+        )
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Macro row
+// Folder section header
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun FolderSectionHeader(
+    folderId:       String?,
+    name:           String,
+    folderIndex:    Int,
+    foldersCount:   Int,
+    isExpanded:     Boolean,
+    accentColor:    Color,
+    onToggleExpand: () -> Unit,
+    onRename:       () -> Unit,
+    onDelete:       () -> Unit,
+    onMoveUp:       () -> Unit,
+    onMoveDown:     () -> Unit,
+) {
+    val colors        = LocalAppColors.current
+    val isNamedFolder = folderId != null
+    var menuExpanded  by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ML_HEADER_HEIGHT.dp)
+            .background(colors.surface)
+            .clickable(onClick = onToggleExpand)
+            .padding(start = ML_PADDING.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector        = if (isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+            contentDescription = null,
+            tint               = colors.onSurfaceSecondary,
+            modifier           = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Icon(
+            imageVector        = if (isExpanded) Icons.Filled.FolderOpen else Icons.Filled.Folder,
+            contentDescription = null,
+            tint               = if (isNamedFolder) accentColor.copy(alpha = 0.7f) else colors.onSurfaceSecondary,
+            modifier           = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            name,
+            color      = colors.onSurface,
+            fontSize   = 14.sp,
+            fontWeight = FontWeight.Medium,
+            modifier   = Modifier.weight(1f),
+        )
+        if (isNamedFolder) {
+            Box {
+                IconButton(onClick = { menuExpanded = true }) {
+                    Icon(Icons.Filled.MoreVert, contentDescription = null, tint = colors.onSurfaceSecondary)
+                }
+                DropdownMenu(
+                    expanded         = menuExpanded,
+                    onDismissRequest = { menuExpanded = false },
+                    modifier         = Modifier.background(colors.surface),
+                ) {
+                    if (folderIndex > 0) {
+                        DropdownMenuItem(
+                            text    = { Text(stringResource(R.string.macro_folder_move_up), color = colors.onSurface, fontSize = 14.sp) },
+                            onClick = { menuExpanded = false; onMoveUp() },
+                        )
+                    }
+                    if (folderIndex < foldersCount - 1) {
+                        DropdownMenuItem(
+                            text    = { Text(stringResource(R.string.macro_folder_move_down), color = colors.onSurface, fontSize = 14.sp) },
+                            onClick = { menuExpanded = false; onMoveDown() },
+                        )
+                    }
+                    DropdownMenuItem(
+                        text    = { Text(stringResource(R.string.macro_folder_rename), color = colors.onSurface, fontSize = 14.sp) },
+                        onClick = { menuExpanded = false; onRename() },
+                    )
+                    DropdownMenuItem(
+                        text    = { Text(stringResource(R.string.macro_folder_delete), color = Color(0xFFCF6679), fontSize = 14.sp) },
+                        onClick = { menuExpanded = false; onDelete() },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Macro row (3-dot context menu)
 // ─────────────────────────────────────────────────────────────────────────────
 
 @Composable
@@ -294,13 +533,15 @@ private fun MacroRow(
     isDragging:         Boolean,
     onEdit:             () -> Unit,
     onDuplicate:        () -> Unit,
+    onMoveToFolder:     () -> Unit,
     onDelete:           () -> Unit,
     dragHandleModifier: Modifier,
 ) {
-    val colors        = LocalAppColors.current
-    val stepCount     = macro.steps.size
-    val totalMs       = macro.steps.totalDurationMs()
-    val summaryLabel  = stringResource(R.string.macropad_macro_list_steps, stepCount, totalMs)
+    val colors       = LocalAppColors.current
+    val stepCount    = macro.steps.size
+    val totalMs      = macro.steps.totalDurationMs()
+    val summaryLabel = stringResource(R.string.macropad_macro_list_steps, stepCount, totalMs)
+    var menuExpanded by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
@@ -318,34 +559,37 @@ private fun MacroRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            Text(
-                summaryLabel,
-                color    = colors.onSurfaceSecondary,
-                fontSize = 12.sp,
-            )
+            Text(summaryLabel, color = colors.onSurfaceSecondary, fontSize = 12.sp)
         }
 
-        IconButton(onClick = onEdit) {
-            Icon(
-                Icons.Filled.Edit,
-                contentDescription = stringResource(R.string.macropad_editor_rename),
-                tint               = colors.onSurfaceSecondary,
-            )
+        Box {
+            IconButton(onClick = { menuExpanded = true }) {
+                Icon(Icons.Filled.MoreVert, contentDescription = null, tint = colors.onSurfaceSecondary)
+            }
+            DropdownMenu(
+                expanded         = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+                modifier         = Modifier.background(colors.surface),
+            ) {
+                DropdownMenuItem(
+                    text    = { Text(stringResource(R.string.macropad_editor_rename), color = colors.onSurface, fontSize = 14.sp) },
+                    onClick = { menuExpanded = false; onEdit() },
+                )
+                DropdownMenuItem(
+                    text    = { Text(stringResource(R.string.macropad_macro_duplicate), color = colors.onSurface, fontSize = 14.sp) },
+                    onClick = { menuExpanded = false; onDuplicate() },
+                )
+                DropdownMenuItem(
+                    text    = { Text(stringResource(R.string.macro_move_to_folder), color = colors.onSurface, fontSize = 14.sp) },
+                    onClick = { menuExpanded = false; onMoveToFolder() },
+                )
+                DropdownMenuItem(
+                    text    = { Text(stringResource(R.string.macropad_macro_delete_title), color = Color(0xFFCF6679), fontSize = 14.sp) },
+                    onClick = { menuExpanded = false; onDelete() },
+                )
+            }
         }
-        IconButton(onClick = onDuplicate) {
-            Icon(
-                Icons.Filled.ContentCopy,
-                contentDescription = stringResource(R.string.macropad_macro_duplicate),
-                tint               = colors.onSurfaceSecondary,
-            )
-        }
-        IconButton(onClick = onDelete) {
-            Icon(
-                Icons.Filled.Delete,
-                contentDescription = stringResource(R.string.macropad_macro_delete_title),
-                tint               = colors.onSurfaceSecondary,
-            )
-        }
+
         Icon(
             imageVector        = Icons.Filled.DragHandle,
             contentDescription = stringResource(R.string.cd_drag_reorder),
@@ -355,4 +599,141 @@ private fun MacroRow(
                 .then(dragHandleModifier),
         )
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// New-macro chip (shown at the bottom of each section)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun NewMacroChip(accentColor: Color, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = ML_SECTION_INDENT.dp, end = ML_PADDING.dp, top = 8.dp, bottom = 8.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .border(1.dp, accentColor.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, tint = accentColor, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(stringResource(R.string.macropad_macro_list_new), color = accentColor, fontSize = 13.sp)
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Folder picker dialog (Move to Folder)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun FolderPickerDialog(
+    title:            String,
+    folders:          List<MacroFolder>,
+    selectedFolderId: String?,
+    unassignedLabel:  String,
+    accentColor:      Color,
+    onSelect:         (String?) -> Unit,
+    onDismiss:        () -> Unit,
+) {
+    val colors      = LocalAppColors.current
+    val folderItems = buildList {
+        add(unassignedLabel to null as String?)
+        folders.forEach { add(it.name to it.id) }
+    }
+    AlertDialog(
+        containerColor   = colors.surface,
+        onDismissRequest = onDismiss,
+        title   = { Text(title, color = colors.onSurface) },
+        text    = {
+            Column {
+                folderItems.forEach { (folderName, fId) ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(fId) }
+                            .padding(vertical = 10.dp, horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            folderName,
+                            color    = if (fId == selectedFolderId) accentColor else colors.onSurface,
+                            fontSize = 15.sp,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (fId == selectedFolderId) {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                tint     = accentColor,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.macropad_editor_cancel), color = colors.onSurfaceSecondary)
+            }
+        },
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Text input dialog (New Folder / Rename Folder)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun TextInputDialog(
+    title:        String,
+    hint:         String,
+    initialValue: String,
+    accentColor:  Color,
+    onConfirm:    (String) -> Unit,
+    onDismiss:    () -> Unit,
+) {
+    val colors = LocalAppColors.current
+    var text   by remember { mutableStateOf(initialValue) }
+
+    AlertDialog(
+        containerColor   = colors.surface,
+        onDismissRequest = onDismiss,
+        title   = { Text(title, color = colors.onSurface) },
+        text    = {
+            OutlinedTextField(
+                value         = text,
+                onValueChange = { text = it },
+                placeholder   = { Text(hint, color = colors.onSurfaceSecondary) },
+                singleLine    = true,
+                colors        = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor   = accentColor,
+                    unfocusedBorderColor = colors.accentBorder,
+                    focusedTextColor     = colors.onSurface,
+                    unfocusedTextColor   = colors.onSurface,
+                    cursorColor          = accentColor,
+                ),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text) }, enabled = text.isNotBlank()) {
+                Text(
+                    stringResource(R.string.macropad_editor_done),
+                    color = if (text.isNotBlank()) accentColor else colors.onSurfaceSecondary,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.macropad_editor_cancel), color = colors.onSurfaceSecondary)
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/MacroListEditor.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/MacroListEditor.kt
@@ -178,7 +178,7 @@ private fun MacroListView(
     val macros         by MacroState.macros.collectAsState()
     val folders        by MacroState.folders.collectAsState()
     val colors         = LocalAppColors.current
-    val unassignedLabel = stringResource(R.string.macro_folder_unassigned)
+    val unassignedLabel = stringResource(R.string.macropad_folder_unassigned)
 
     // Section expand/collapse: null key = "Unassigned"; absent = expanded
     val expandedSections = remember { mutableStateMapOf<String?, Boolean>() }
@@ -256,7 +256,7 @@ private fun MacroListView(
             IconButton(onClick = { showNewFolder = true }) {
                 Icon(
                     Icons.Filled.CreateNewFolder,
-                    contentDescription = stringResource(R.string.macro_folder_new),
+                    contentDescription = stringResource(R.string.macropad_folder_new),
                     tint               = accentColor,
                 )
             }
@@ -371,7 +371,7 @@ private fun MacroListView(
         val macroId        = movingMacroId!!
         val currentFolderId = macros.firstOrNull { it.id == macroId }?.folderId
         FolderPickerDialog(
-            title            = stringResource(R.string.macro_folder_move_title),
+            title            = stringResource(R.string.macropad_folder_move_title),
             folders          = folders,
             selectedFolderId = currentFolderId,
             unassignedLabel  = unassignedLabel,
@@ -385,8 +385,8 @@ private fun MacroListView(
         val fId         = renamingFolderId!!
         val currentName = folders.firstOrNull { it.id == fId }?.name ?: ""
         TextInputDialog(
-            title       = stringResource(R.string.macro_folder_rename),
-            hint        = stringResource(R.string.macro_folder_name_hint),
+            title       = stringResource(R.string.macropad_folder_rename),
+            hint        = stringResource(R.string.macropad_folder_name_hint),
             initialValue = currentName,
             accentColor = accentColor,
             onConfirm   = { name ->
@@ -402,8 +402,8 @@ private fun MacroListView(
         AlertDialog(
             containerColor   = colors.surface,
             onDismissRequest = { deletingFolderId = null },
-            title   = { Text(stringResource(R.string.macro_folder_delete), color = colors.onSurface) },
-            text    = { Text(stringResource(R.string.macro_folder_delete_confirm), color = colors.onSurfaceSecondary) },
+            title   = { Text(stringResource(R.string.macropad_folder_delete), color = colors.onSurface) },
+            text    = { Text(stringResource(R.string.macropad_folder_delete_confirm), color = colors.onSurfaceSecondary) },
             confirmButton = {
                 TextButton(onClick = { MacroState.deleteFolder(fId); deletingFolderId = null }) {
                     Text(stringResource(R.string.macropad_editor_confirm), color = Color(0xFFCF6679))
@@ -419,8 +419,8 @@ private fun MacroListView(
 
     if (showNewFolder) {
         TextInputDialog(
-            title        = stringResource(R.string.macro_folder_new),
-            hint         = stringResource(R.string.macro_folder_name_hint),
+            title        = stringResource(R.string.macropad_folder_new),
+            hint         = stringResource(R.string.macropad_folder_name_hint),
             initialValue = "",
             accentColor  = accentColor,
             onConfirm    = { name ->
@@ -489,7 +489,7 @@ private fun FolderSectionHeader(
         if (isNamedFolder) {
             Box {
                 IconButton(onClick = { menuExpanded = true }) {
-                    Icon(Icons.Filled.MoreVert, contentDescription = null, tint = colors.onSurfaceSecondary)
+                    Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.cd_more_options), tint = colors.onSurfaceSecondary)
                 }
                 DropdownMenu(
                     expanded         = menuExpanded,
@@ -498,22 +498,22 @@ private fun FolderSectionHeader(
                 ) {
                     if (folderIndex > 0) {
                         DropdownMenuItem(
-                            text    = { Text(stringResource(R.string.macro_folder_move_up), color = colors.onSurface, fontSize = 14.sp) },
+                            text    = { Text(stringResource(R.string.macropad_folder_move_up), color = colors.onSurface, fontSize = 14.sp) },
                             onClick = { menuExpanded = false; onMoveUp() },
                         )
                     }
                     if (folderIndex < foldersCount - 1) {
                         DropdownMenuItem(
-                            text    = { Text(stringResource(R.string.macro_folder_move_down), color = colors.onSurface, fontSize = 14.sp) },
+                            text    = { Text(stringResource(R.string.macropad_folder_move_down), color = colors.onSurface, fontSize = 14.sp) },
                             onClick = { menuExpanded = false; onMoveDown() },
                         )
                     }
                     DropdownMenuItem(
-                        text    = { Text(stringResource(R.string.macro_folder_rename), color = colors.onSurface, fontSize = 14.sp) },
+                        text    = { Text(stringResource(R.string.macropad_folder_rename), color = colors.onSurface, fontSize = 14.sp) },
                         onClick = { menuExpanded = false; onRename() },
                     )
                     DropdownMenuItem(
-                        text    = { Text(stringResource(R.string.macro_folder_delete), color = Color(0xFFCF6679), fontSize = 14.sp) },
+                        text    = { Text(stringResource(R.string.macropad_folder_delete), color = Color(0xFFCF6679), fontSize = 14.sp) },
                         onClick = { menuExpanded = false; onDelete() },
                     )
                 }
@@ -564,7 +564,7 @@ private fun MacroRow(
 
         Box {
             IconButton(onClick = { menuExpanded = true }) {
-                Icon(Icons.Filled.MoreVert, contentDescription = null, tint = colors.onSurfaceSecondary)
+                Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.cd_more_options), tint = colors.onSurfaceSecondary)
             }
             DropdownMenu(
                 expanded         = menuExpanded,
@@ -580,7 +580,7 @@ private fun MacroRow(
                     onClick = { menuExpanded = false; onDuplicate() },
                 )
                 DropdownMenuItem(
-                    text    = { Text(stringResource(R.string.macro_move_to_folder), color = colors.onSurface, fontSize = 14.sp) },
+                    text    = { Text(stringResource(R.string.macropad_move_to_folder), color = colors.onSurface, fontSize = 14.sp) },
                     onClick = { menuExpanded = false; onMoveToFolder() },
                 )
                 DropdownMenuItem(

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/MacroState.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/MacroState.kt
@@ -11,12 +11,16 @@ import kotlinx.coroutines.flow.asStateFlow
  *
  * Follows the project-wide singleton-state pattern: private [MutableStateFlow] backing
  * fields, read-only [StateFlow] exposed to UI. Every mutation triggers
- * [SettingsManager.saveMacroData] for DataStore persistence.
+ * [SettingsManager.saveMacroData] (or [SettingsManager.saveMacroFolderData]) for
+ * DataStore persistence.
  */
 object MacroState {
 
     private val _macros = MutableStateFlow<List<Macro>>(emptyList())
     val macros: StateFlow<List<Macro>> = _macros.asStateFlow()
+
+    private val _folders = MutableStateFlow<List<MacroFolder>>(emptyList())
+    val folders: StateFlow<List<MacroFolder>> = _folders.asStateFlow()
 
     // -------------------------------------------------------------------------
     // Initialization (called by SettingsManager.init)
@@ -26,8 +30,12 @@ object MacroState {
         _macros.value = macros
     }
 
+    internal fun loadFoldersFrom(folders: List<MacroFolder>) {
+        _folders.value = folders
+    }
+
     // -------------------------------------------------------------------------
-    // CRUD
+    // Macro CRUD
     // -------------------------------------------------------------------------
 
     fun addMacro(macro: Macro) {
@@ -52,8 +60,59 @@ object MacroState {
         SettingsManager.saveMacroData()
     }
 
+    /** Replaces the entire macro list (used for flat full-list reorder — legacy callers). */
     fun reorderMacros(newList: List<Macro>) {
         _macros.value = newList
         SettingsManager.saveMacroData()
     }
+
+    /**
+     * Reorders macros within a single folder/section without disturbing macros in
+     * other sections. [reorderedSection] must contain the same macros that currently
+     * belong to [folderId], just in a different order.
+     */
+    fun reorderMacrosInFolder(folderId: String?, reorderedSection: List<Macro>) {
+        val current = _macros.value.toMutableList()
+        val indices = current.mapIndexedNotNull { i, m -> if (m.folderId == folderId) i else null }
+        indices.zip(reorderedSection).forEach { (idx, macro) -> current[idx] = macro }
+        _macros.value = current
+        SettingsManager.saveMacroData()
+    }
+
+    /** Moves [macroId] to [folderId] (pass `null` for the "Unassigned" section). */
+    fun moveMacroToFolder(macroId: String, folderId: String?) {
+        _macros.value = _macros.value.map { if (it.id == macroId) it.copy(folderId = folderId) else it }
+        SettingsManager.saveMacroData()
+    }
+
+    // -------------------------------------------------------------------------
+    // Folder CRUD
+    // -------------------------------------------------------------------------
+
+    fun addFolder(folder: MacroFolder) {
+        _folders.value = _folders.value + folder
+        SettingsManager.saveMacroFolderData()
+    }
+
+    fun renameFolder(id: String, newName: String) {
+        _folders.value = _folders.value.map { if (it.id == id) it.copy(name = newName) else it }
+        SettingsManager.saveMacroFolderData()
+    }
+
+    /**
+     * Deletes the folder [folderId] and moves all macros that belonged to it to the
+     * "Unassigned" section (sets their [Macro.folderId] to `null`).
+     */
+    fun deleteFolder(folderId: String) {
+        _macros.value = _macros.value.map { if (it.folderId == folderId) it.copy(folderId = null) else it }
+        _folders.value = _folders.value.filter { it.id != folderId }
+        SettingsManager.saveMacroData()
+        SettingsManager.saveMacroFolderData()
+    }
+
+    fun reorderFolders(newList: List<MacroFolder>) {
+        _folders.value = newList
+        SettingsManager.saveMacroFolderData()
+    }
 }
+

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/PadActionPicker.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/PadActionPicker.kt
@@ -293,57 +293,119 @@ internal fun GamepadButtonPicker(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Macro picker — lists global macros from MacroState
+// Macro picker — folder dropdown + macro dropdown
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Two-step macro selector:
+ * 1. **Folder dropdown** — "Nicht zugeordnet" first, then named folders in stored order.
+ * 2. **Macro dropdown** — macros belonging to the selected folder only.
+ *
+ * Pre-selects the folder and macro that match [current.macroId] on first composition.
+ * When the selected folder changes, the first macro in that folder is auto-selected.
+ */
 @Composable
 internal fun MacroPicker(
     current:     PadAction.Macro,
     accentColor: Color,
     onChange:    (PadAction) -> Unit,
 ) {
-    val macros   by MacroState.macros.collectAsState()
-    var expanded by remember { mutableStateOf(false) }
-    val colors   = LocalAppColors.current
+    val macros          by MacroState.macros.collectAsState()
+    val folders         by MacroState.folders.collectAsState()
+    val colors          = LocalAppColors.current
+    val unassignedLabel = stringResource(R.string.macro_folder_unassigned)
+    val folderEmptyLabel = stringResource(R.string.macro_picker_folder_empty)
 
-    val currentMacroName = macros.firstOrNull { it.id == current.macroId }?.name
-        ?: stringResource(R.string.macropad_macro_picker_unknown)
+    // Derive the selected folder from the current macro; reset when macroId changes
+    val initialFolderId = remember(current.macroId) {
+        macros.firstOrNull { it.id == current.macroId }?.folderId
+    }
+    var selectedFolderId by remember(current.macroId) { mutableStateOf(initialFolderId) }
 
-    Box {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
-                .border(1.dp, accentColor.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
-                .clickable { expanded = true }
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(currentMacroName, color = accentColor, fontSize = 14.sp, modifier = Modifier.weight(1f))
-            Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = accentColor)
+    val macrosInFolder = remember(macros, selectedFolderId) {
+        macros.filter { it.folderId == selectedFolderId }
+    }
+
+    var folderExpanded by remember { mutableStateOf(false) }
+    var macroExpanded  by remember { mutableStateOf(false) }
+
+    // Folder display list: (label, folderId)
+    val folderItems = remember(folders) {
+        buildList {
+            add(unassignedLabel to null as String?)
+            folders.forEach { f -> add(f.name to f.id) }
+        }
+    }
+    val selectedFolderLabel = folderItems.firstOrNull { it.second == selectedFolderId }?.first ?: unassignedLabel
+    val selectedMacroName   = macros.firstOrNull { it.id == current.macroId }?.name
+        ?: macrosInFolder.firstOrNull()?.name
+        ?: ""
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // ── Folder dropdown ──────────────────────────────────────────────────
+        Box {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, accentColor.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                    .clickable { folderExpanded = true }
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(selectedFolderLabel, color = accentColor, fontSize = 14.sp, modifier = Modifier.weight(1f))
+                Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = accentColor)
+            }
+            DropdownMenu(
+                expanded         = folderExpanded,
+                onDismissRequest = { folderExpanded = false },
+                modifier         = Modifier.background(colors.surface),
+            ) {
+                folderItems.forEach { (label, fId) ->
+                    DropdownMenuItem(
+                        text    = { Text(label, color = if (fId == selectedFolderId) accentColor else colors.onSurface, fontSize = 14.sp) },
+                        onClick = {
+                            selectedFolderId = fId
+                            folderExpanded   = false
+                            val first = macros.filter { it.folderId == fId }.firstOrNull()
+                            if (first != null) onChange(PadAction.Macro(first.id))
+                        },
+                    )
+                }
+            }
         }
 
-        DropdownMenu(
-            expanded         = expanded,
-            onDismissRequest = { expanded = false },
-            modifier         = Modifier.background(colors.surface),
-        ) {
-            if (macros.isEmpty()) {
-                DropdownMenuItem(
-                    text    = { Text(stringResource(R.string.macropad_macro_picker_no_macros), color = colors.onSurfaceSecondary, fontSize = 14.sp) },
-                    onClick = { expanded = false },
+        // ── Macro dropdown (filtered by selected folder) ─────────────────────
+        Box {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, accentColor.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                    .clickable(enabled = macrosInFolder.isNotEmpty()) { macroExpanded = true }
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                val label = if (macrosInFolder.isEmpty()) folderEmptyLabel else selectedMacroName
+                Text(
+                    label,
+                    color    = if (macrosInFolder.isEmpty()) colors.onSurfaceSecondary else accentColor,
+                    fontSize = 14.sp,
+                    modifier = Modifier.weight(1f),
                 )
-            } else {
-                macros.forEach { macro ->
+                if (macrosInFolder.isNotEmpty()) {
+                    Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = accentColor)
+                }
+            }
+            DropdownMenu(
+                expanded         = macroExpanded,
+                onDismissRequest = { macroExpanded = false },
+                modifier         = Modifier.background(colors.surface),
+            ) {
+                macrosInFolder.forEach { macro ->
                     DropdownMenuItem(
-                        text = {
-                            Text(
-                                macro.name,
-                                color    = if (macro.id == current.macroId) accentColor else colors.onSurface,
-                                fontSize = 14.sp,
-                            )
-                        },
-                        onClick = { onChange(PadAction.Macro(macro.id)); expanded = false },
+                        text    = { Text(macro.name, color = if (macro.id == current.macroId) accentColor else colors.onSurface, fontSize = 14.sp) },
+                        onClick = { onChange(PadAction.Macro(macro.id)); macroExpanded = false },
                     )
                 }
             }

--- a/app/src/main/java/com/stormpanda/megingiard/macropad/PadActionPicker.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/macropad/PadActionPicker.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -313,14 +314,21 @@ internal fun MacroPicker(
     val macros          by MacroState.macros.collectAsState()
     val folders         by MacroState.folders.collectAsState()
     val colors          = LocalAppColors.current
-    val unassignedLabel = stringResource(R.string.macro_folder_unassigned)
-    val folderEmptyLabel = stringResource(R.string.macro_picker_folder_empty)
+    val unassignedLabel = stringResource(R.string.macropad_folder_unassigned)
+    val folderEmptyLabel = stringResource(R.string.macropad_picker_folder_empty)
 
-    // Derive the selected folder from the current macro; reset when macroId changes
-    val initialFolderId = remember(current.macroId) {
-        macros.firstOrNull { it.id == current.macroId }?.folderId
+    // selectedFolderId is derived from the macro's persisted folderId once macros load.
+    // A LaunchedEffect keeps it in sync when macros arrive from DataStore.
+    // Once the user explicitly picks a folder, userHasChosenFolder prevents the effect
+    // from overwriting that deliberate choice.
+    var userHasChosenFolder by remember(current.macroId) { mutableStateOf(false) }
+    var selectedFolderId    by remember(current.macroId) { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(current.macroId, macros) {
+        if (!userHasChosenFolder) {
+            selectedFolderId = macros.firstOrNull { it.id == current.macroId }?.folderId
+        }
     }
-    var selectedFolderId by remember(current.macroId) { mutableStateOf(initialFolderId) }
 
     val macrosInFolder = remember(macros, selectedFolderId) {
         macros.filter { it.folderId == selectedFolderId }
@@ -330,7 +338,7 @@ internal fun MacroPicker(
     var macroExpanded  by remember { mutableStateOf(false) }
 
     // Folder display list: (label, folderId)
-    val folderItems = remember(folders) {
+    val folderItems = remember(folders, unassignedLabel) {
         buildList {
             add(unassignedLabel to null as String?)
             folders.forEach { f -> add(f.name to f.id) }
@@ -365,8 +373,9 @@ internal fun MacroPicker(
                     DropdownMenuItem(
                         text    = { Text(label, color = if (fId == selectedFolderId) accentColor else colors.onSurface, fontSize = 14.sp) },
                         onClick = {
-                            selectedFolderId = fId
-                            folderExpanded   = false
+                            userHasChosenFolder = true
+                            selectedFolderId    = fId
+                            folderExpanded      = false
                             val first = macros.filter { it.folderId == fId }.firstOrNull()
                             if (first != null) onChange(PadAction.Macro(first.id))
                         },

--- a/app/src/main/java/com/stormpanda/megingiard/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/SettingsManager.kt
@@ -21,6 +21,7 @@ import com.stormpanda.megingiard.ui.ThemeMode
 import com.stormpanda.megingiard.keyboard.KbLayout
 import com.stormpanda.megingiard.keyboard.KbMouseBtnPos
 import com.stormpanda.megingiard.macropad.Macro
+import com.stormpanda.megingiard.macropad.MacroFolder
 import com.stormpanda.megingiard.macropad.MacroPadState
 import com.stormpanda.megingiard.macropad.MacroState
 import com.stormpanda.megingiard.macropad.PadProfile
@@ -82,6 +83,7 @@ object SettingsManager {
     private val KEY_MACROPAD_PROFILES           = stringPreferencesKey("macropad_profiles")
     private val KEY_MACROPAD_ACTIVE_PROFILE_ID  = stringPreferencesKey("macropad_active_profile_id")
     private val KEY_MACROPAD_MACROS             = stringPreferencesKey("macropad_macros")
+    private val KEY_MACROPAD_MACRO_FOLDERS      = stringPreferencesKey("macropad_macro_folders")
 
     // Keyboard settings
     private val KEY_KB_LAYOUT = stringPreferencesKey("kb_layout")
@@ -250,6 +252,17 @@ object SettingsManager {
                     MacroState.loadFrom(macros)
                 } else {
                     MacroState.loadFrom(emptyList())
+                }
+
+                // MacroPad macro folders
+                val foldersJson = prefs[KEY_MACROPAD_MACRO_FOLDERS]
+                if (foldersJson != null) {
+                    val folders = runCatching {
+                        macropadJson.decodeFromString<List<MacroFolder>>(foldersJson)
+                    }.getOrElse { emptyList() }
+                    MacroState.loadFoldersFrom(folders)
+                } else {
+                    MacroState.loadFoldersFrom(emptyList())
                 }
             }
         }
@@ -443,6 +456,19 @@ object SettingsManager {
         scope.launch {
             dataStore.edit { prefs ->
                 prefs[KEY_MACROPAD_MACROS] = macropadJson.encodeToString(macros)
+            }
+        }
+    }
+
+    /**
+     * Persists the macro folder list to DataStore.
+     * Called by [MacroState] mutators whenever the folder list changes.
+     */
+    fun saveMacroFolderData() {
+        val folders = MacroState.folders.value
+        scope.launch {
+            dataStore.edit { prefs ->
+                prefs[KEY_MACROPAD_MACRO_FOLDERS] = macropadJson.encodeToString(folders)
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -248,4 +248,17 @@ Einstellungen öffnen, um ein Layout zu erstellen.</string>
     <string name="macropad_macro_timeline_tick">%1$d ms</string>
     <!-- Schritt-Timing: %1$d = Startzeit ms, %2$d = Dauer ms -->
     <string name="macropad_macro_step_timing">@%1$d ms  ⟶  %2$d ms</string>
+
+    <!-- MacroPad-Makro-Ordner -->
+    <string name="macro_folder_unassigned">Nicht zugeordnet</string>
+    <string name="macro_folder_new">Neuer Ordner</string>
+    <string name="macro_folder_rename">Ordner umbenennen</string>
+    <string name="macro_folder_delete">Ordner löschen</string>
+    <string name="macro_folder_delete_confirm">Alle Makros in diesem Ordner werden &#8222;Nicht zugeordnet&#8220;.</string>
+    <string name="macro_folder_name_hint">Ordnername</string>
+    <string name="macro_folder_move_title">In Ordner verschieben</string>
+    <string name="macro_folder_move_up">Nach oben</string>
+    <string name="macro_folder_move_down">Nach unten</string>
+    <string name="macro_move_to_folder">In Ordner verschieben…</string>
+    <string name="macro_picker_folder_empty">Keine Makros in diesem Ordner</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -250,15 +250,16 @@ Einstellungen öffnen, um ein Layout zu erstellen.</string>
     <string name="macropad_macro_step_timing">@%1$d ms  ⟶  %2$d ms</string>
 
     <!-- MacroPad-Makro-Ordner -->
-    <string name="macro_folder_unassigned">Nicht zugeordnet</string>
-    <string name="macro_folder_new">Neuer Ordner</string>
-    <string name="macro_folder_rename">Ordner umbenennen</string>
-    <string name="macro_folder_delete">Ordner löschen</string>
-    <string name="macro_folder_delete_confirm">Alle Makros in diesem Ordner werden &#8222;Nicht zugeordnet&#8220;.</string>
-    <string name="macro_folder_name_hint">Ordnername</string>
-    <string name="macro_folder_move_title">In Ordner verschieben</string>
-    <string name="macro_folder_move_up">Nach oben</string>
-    <string name="macro_folder_move_down">Nach unten</string>
-    <string name="macro_move_to_folder">In Ordner verschieben…</string>
-    <string name="macro_picker_folder_empty">Keine Makros in diesem Ordner</string>
+    <string name="macropad_folder_unassigned">Nicht zugeordnet</string>
+    <string name="macropad_folder_new">Neuer Ordner</string>
+    <string name="macropad_folder_rename">Ordner umbenennen</string>
+    <string name="macropad_folder_delete">Ordner löschen</string>
+    <string name="macropad_folder_delete_confirm">Alle Makros in diesem Ordner werden dem Bereich &#8222;Nicht zugeordnet&#8220; zugeordnet.</string>
+    <string name="macropad_folder_name_hint">Ordnername</string>
+    <string name="macropad_folder_move_title">In Ordner verschieben</string>
+    <string name="macropad_folder_move_up">Nach oben</string>
+    <string name="macropad_folder_move_down">Nach unten</string>
+    <string name="macropad_move_to_folder">In Ordner verschieben…</string>
+    <string name="macropad_picker_folder_empty">Keine Makros in diesem Ordner</string>
+    <string name="cd_more_options">Weitere Optionen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,4 +245,17 @@ Open Settings to create a layout.</string>
     <string name="macropad_macro_timeline_tick">%1$dms</string>
     <!-- %1$d = start time ms, %2$d = duration ms -->
     <string name="macropad_macro_step_timing">@%1$dms  ⟶  %2$dms</string>
+
+    <!-- MacroPad macro folders -->
+    <string name="macro_folder_unassigned">Unassigned</string>
+    <string name="macro_folder_new">New Folder</string>
+    <string name="macro_folder_rename">Rename Folder</string>
+    <string name="macro_folder_delete">Delete Folder</string>
+    <string name="macro_folder_delete_confirm">All macros in this folder will be moved to &#8220;Unassigned&#8221;.</string>
+    <string name="macro_folder_name_hint">Folder name</string>
+    <string name="macro_folder_move_title">Move to Folder</string>
+    <string name="macro_folder_move_up">Move Up</string>
+    <string name="macro_folder_move_down">Move Down</string>
+    <string name="macro_move_to_folder">Move to Folder…</string>
+    <string name="macro_picker_folder_empty">No macros in this folder</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,15 +247,16 @@ Open Settings to create a layout.</string>
     <string name="macropad_macro_step_timing">@%1$dms  ⟶  %2$dms</string>
 
     <!-- MacroPad macro folders -->
-    <string name="macro_folder_unassigned">Unassigned</string>
-    <string name="macro_folder_new">New Folder</string>
-    <string name="macro_folder_rename">Rename Folder</string>
-    <string name="macro_folder_delete">Delete Folder</string>
-    <string name="macro_folder_delete_confirm">All macros in this folder will be moved to &#8220;Unassigned&#8221;.</string>
-    <string name="macro_folder_name_hint">Folder name</string>
-    <string name="macro_folder_move_title">Move to Folder</string>
-    <string name="macro_folder_move_up">Move Up</string>
-    <string name="macro_folder_move_down">Move Down</string>
-    <string name="macro_move_to_folder">Move to Folder…</string>
-    <string name="macro_picker_folder_empty">No macros in this folder</string>
+    <string name="macropad_folder_unassigned">Unassigned</string>
+    <string name="macropad_folder_new">New Folder</string>
+    <string name="macropad_folder_rename">Rename Folder</string>
+    <string name="macropad_folder_delete">Delete Folder</string>
+    <string name="macropad_folder_delete_confirm">All macros in this folder will be moved to &#8220;Unassigned&#8221;.</string>
+    <string name="macropad_folder_name_hint">Folder name</string>
+    <string name="macropad_folder_move_title">Move to Folder</string>
+    <string name="macropad_folder_move_up">Move Up</string>
+    <string name="macropad_folder_move_down">Move Down</string>
+    <string name="macropad_move_to_folder">Move to Folder…</string>
+    <string name="macropad_picker_folder_empty">No macros in this folder</string>
+    <string name="cd_more_options">More options</string>
 </resources>

--- a/docs/features/macropad/FEATURE.md
+++ b/docs/features/macropad/FEATURE.md
@@ -92,14 +92,14 @@ Each button supports one of the following actions:
 - Folders are stored as `List<MacroFolder>` under the DataStore key `macropad_macro_folders`. The `Macro.folderId` field defaults to `null` — existing saved data is therefore **automatically backward-compatible** with no migration required.
 - The **Macro Library editor** (`MacroListEditor`) groups macros into folder sections:
   - The **"Nicht zugeordnet"** section is always displayed **first**. It cannot be renamed or deleted.
-  - Named folders follow in user-defined order and can be reordered via drag handles on their section headers.
+  - Named folders follow in user-defined order and can be reordered via **Move Up** / **Move Down** context menu actions on their section headers.
   - Each section is **collapsible** (expand/collapse toggle on the header).
   - Within a section, macros can be **reordered** by drag handle (reorder is scoped to the section).
 - Folder **CRUD** is available via context menus in the section header:
   - **Rename** — In-place rename dialog.
   - **Delete** — Confirmation dialog warns that all macros in the folder will be moved to "Nicht zugeordnet". After confirmation, all affected macros have their `folderId` set to `null`.
 - A **"Neuer Ordner"** button is provided in the macro library top bar to create a new folder.
-- Macros can be **moved to a different folder** via a context menu entry ("In Ordner verschieben…") on each macro row. A simple dialog presents a flat list of available folders (including "Nicht zugeordnet" at the top). Selecting an entry updates `Macro.folderId` and immediately repersists.
+- Macros can be **moved to a different folder** via a context menu entry ("In Ordner verschieben…") on each macro row. A simple dialog presents a flat list of available folders (including "Nicht zugeordnet" at the top). Selecting an entry updates `Macro.folderId` and immediately persists.
 - Duplicating a macro preserves the original's `folderId` — the copy lands in the same folder.
 - The **`MacroPicker`** in `PadActionPicker` uses a two-step selection flow:
   1. **Folder dropdown** — lists "Nicht zugeordnet" first, then all named folders in their stored order. Pre-selects the folder of the currently assigned macro (if any).

--- a/docs/features/macropad/FEATURE.md
+++ b/docs/features/macropad/FEATURE.md
@@ -85,6 +85,27 @@ Each button supports one of the following actions:
 - The macro editor shows a **visual horizontal timeline** (Canvas, 0.3 dp/ms scale) colour-coded by step type (accent = Gamepad Button, orange = Joystick, blue = D-Pad), plus a scrollable step list for editing individual steps.
 - Steps are configured in **`MacroStepEditDialog`** which provides: step-type chips (Gamepad / Joystick / D-Pad), gamepad button dropdown, 3×3 direction grid for joystick/D-Pad, a magnitude slider (0–1, default 1) for joystick, and numeric fields for start/duration timing.
 
+### FR-P8: Macro Folders
+
+- The macro library MUST support **named folders** to group macros. Folders have one level of depth only — no sub-folders.
+- Every macro may belong to exactly **one folder** (identified by `folderId: String?`). Macros with `folderId = null` are implicitly assigned to the **"Nicht zugeordnet"** (Unassigned) virtual folder.
+- Folders are stored as `List<MacroFolder>` under the DataStore key `macropad_macro_folders`. The `Macro.folderId` field defaults to `null` — existing saved data is therefore **automatically backward-compatible** with no migration required.
+- The **Macro Library editor** (`MacroListEditor`) groups macros into folder sections:
+  - The **"Nicht zugeordnet"** section is always displayed **first**. It cannot be renamed or deleted.
+  - Named folders follow in user-defined order and can be reordered via drag handles on their section headers.
+  - Each section is **collapsible** (expand/collapse toggle on the header).
+  - Within a section, macros can be **reordered** by drag handle (reorder is scoped to the section).
+- Folder **CRUD** is available via context menus in the section header:
+  - **Rename** — In-place rename dialog.
+  - **Delete** — Confirmation dialog warns that all macros in the folder will be moved to "Nicht zugeordnet". After confirmation, all affected macros have their `folderId` set to `null`.
+- A **"Neuer Ordner"** button is provided in the macro library top bar to create a new folder.
+- Macros can be **moved to a different folder** via a context menu entry ("In Ordner verschieben…") on each macro row. A simple dialog presents a flat list of available folders (including "Nicht zugeordnet" at the top). Selecting an entry updates `Macro.folderId` and immediately repersists.
+- Duplicating a macro preserves the original's `folderId` — the copy lands in the same folder.
+- The **`MacroPicker`** in `PadActionPicker` uses a two-step selection flow:
+  1. **Folder dropdown** — lists "Nicht zugeordnet" first, then all named folders in their stored order. Pre-selects the folder of the currently assigned macro (if any).
+  2. **Macro dropdown** — shows only macros belonging to the folder selected in step 1. Pre-selects the currently assigned macro (if any).
+  - If the selected folder has no macros, the macro dropdown shows a disabled placeholder ("Keine Makros in diesem Ordner").
+
 ---
 
 ## Technical Implementation
@@ -110,6 +131,72 @@ MacroPadEditor (Composable, opened from MacroPadToolSettings)
 ### Data Model
 
 `PadProfile` and all sub-types are `@Serializable` data classes (sealed class `PadAction` with `@SerialName` discriminators). The full list of profiles is serialised to a single JSON string stored in DataStore under the key `macropad_profiles`. The active profile ID is stored separately under `macropad_active_profile_id`.
+
+**Macro Folder data model** — new in `MacroData.kt`:
+
+```kotlin
+@Serializable
+data class MacroFolder(
+    val id: String,   // UUID
+    val name: String,
+)
+```
+
+The `Macro` data class gains one optional field (default `null` → fully backward-compatible):
+
+```kotlin
+@Serializable
+data class Macro(
+    val id: String,
+    val name: String,
+    val folderId: String? = null,   // null → "Nicht zugeordnet"
+    val steps: List<MacroStep> = emptyList(),
+)
+```
+
+`List<MacroFolder>` is persisted under the DataStore key `macropad_macro_folders`. On load `SettingsManager` calls `MacroState.loadFoldersFrom(folders)`. Because `Macro.folderId` defaults to `null`, no JSON migration is needed — existing saves automatically produce unassigned macros.
+
+**`MacroState` additions:**
+
+```kotlin
+// New flows
+val folders: StateFlow<List<MacroFolder>>
+
+// New CRUD
+fun addFolder(folder: MacroFolder)
+fun renameFolder(id: String, newName: String)
+fun deleteFolder(folderId: String)       // moves contained macros to folderId=null
+fun reorderFolders(newList: List<MacroFolder>)
+fun moveMacroToFolder(macroId: String, folderId: String?)
+
+// Init hook
+internal fun loadFoldersFrom(folders: List<MacroFolder>)
+```
+
+Every mutation calls `SettingsManager.saveMacroFolderData()` (new save function alongside the existing `saveMacroData()`).
+
+**`MacroListEditor` rendering model:**
+
+```
+MacroListEditor
+  └── MacroListView
+        ├── FolderSection("Nicht zugeordnet", collapsible, no rename/delete)
+        │     └── MacroRow... (drag-reorder scoped to section)
+        ├── FolderSection(folder1.name, collapsible, rename/delete context menu, drag handle)
+        │     └── MacroRow... (drag-reorder scoped to section)
+        └── ...
+        └── [Neuer Ordner] button in top bar
+```
+
+Context menu actions per macro row: Edit, Duplicate, **In Ordner verschieben…**, Delete.
+Context menu actions per named folder header: **Umbenennen**, **Löschen**.
+
+**`MacroPicker` in `PadActionPicker`** replaces the current single dropdown with two:
+
+1. `FolderDropdown` — items: `[("Nicht zugeordnet", null), (folder.name, folder.id), …]` in stored order. On change: updates `selectedFolderId`, resets `selectedMacroId` to first macro in new folder (or null if empty).
+2. `MacroDropdown` — items filtered by `selectedFolderId`; disabled with placeholder label `macro_picker_folder_empty` when filtered list is empty.
+
+Pre-selection on open: resolve `currentMacroId` → find its `folderId` → pre-select that folder → pre-select that macro.
 
 ```
 PadProfile
@@ -242,25 +329,25 @@ The editor canvas supports an optional snap grid rendered behind the draggable b
 
 ### Source Files
 
-| File                         | Responsibility                                                                                                                                   |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `MacroPadScreen.kt`          | Use-mode Composable: pad render, multi-touch input, injector lifecycle                                                                           |
-| `MacroPadEditor.kt`          | Full-screen layout editor: profile CRUD, drag-repositioning, button config; toolbar chips for Macros… and Add Macro Button; grid toggle overlay  |
-| `PadCanvas.kt`               | Editor pad canvas: button drag positioning, grid overlay rendering (`GridMode`, `GridOverlay`), snap functions (`snapRectangular`, `snapRadial`) |
-| `MacroPadToolSettings.kt`    | Tool-settings panel: profile picker, shape/size controls, Edit Layout button                                                                     |
-| `MacroPadState.kt`           | Singleton state: profiles + active profile, CRUD, persistence trigger                                                                            |
-| `MacroPadLayout.kt`          | Serializable data model: `PadProfile`, `PadButton`, `PadAction` (incl. `PadAction.Macro`)                                                        |
-| `MacroData.kt`               | Macro data model: `Macro`, `MacroStep` sealed class, `JoystickStick` enum                                                                        |
-| `MacroState.kt`              | Singleton global macro library: CRUD methods, loaded by `SettingsManager`                                                                        |
-| `MacroExecutor.kt`           | Fire-and-forget macro playback: compiles steps to sorted event list, replays with coroutine delays                                               |
-| `MacroListEditor.kt`         | Full-screen macro library editor (list view + inline navigation to timeline)                                                                     |
-| `MacroTimelineEditor.kt`     | Single-macro step timeline editor: visual Canvas timeline + step list                                                                            |
-| `MacroStepEditDialog.kt`     | Modal dialog for creating/editing a single `MacroStep`                                                                                           |
-| `PadActionPicker.kt`         | Action-type picker for button editing, including `MacroPicker` for Macro type                                                                    |
-| `PadButtonEditDialog.kt`     | Button create/edit dialog; `initialAction` param for pre-setting Macro action                                                                    |
-| `GamepadInjector.kt`         | Public facade over `ShellGamepadInjector` (incl. `joystick()` for ABS axes)                                                                      |
-| `ShellGamepadInjector.kt`    | Native binary lifecycle + writer thread; handles GD/GU/HD/JS commands                                                                            |
-| `GamepadKeycodes.kt`         | Linux BTN\_\* + ABS\_\* constants + preset list                                                                                                  |
-| `MouseInjector.kt`           | Public facade over `ShellMouseInjector`                                                                                                          |
-| `ShellMouseInjector.kt`      | Native binary lifecycle + MOVE-coalescing writer thread for mouse injection                                                                      |
-| `../keyboard/KeyInjector.kt` | Shared key injection facade (reused for `KeyboardKey` actions)                                                                                   |
+| File                         | Responsibility                                                                                                                                           |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MacroPadScreen.kt`          | Use-mode Composable: pad render, multi-touch input, injector lifecycle                                                                                   |
+| `MacroPadEditor.kt`          | Full-screen layout editor: profile CRUD, drag-repositioning, button config; toolbar chips for Macros… and Add Macro Button; grid toggle overlay          |
+| `PadCanvas.kt`               | Editor pad canvas: button drag positioning, grid overlay rendering (`GridMode`, `GridOverlay`), snap functions (`snapRectangular`, `snapRadial`)         |
+| `MacroPadToolSettings.kt`    | Tool-settings panel: profile picker, shape/size controls, Edit Layout button                                                                             |
+| `MacroPadState.kt`           | Singleton state: profiles + active profile, CRUD, persistence trigger                                                                                    |
+| `MacroPadLayout.kt`          | Serializable data model: `PadProfile`, `PadButton`, `PadAction` (incl. `PadAction.Macro`)                                                                |
+| `MacroData.kt`               | Macro data model: `Macro` (incl. `folderId`), `MacroFolder`, `MacroStep` sealed class, `JoystickStick` enum                                              |
+| `MacroState.kt`              | Singleton global macro library + folder library: CRUD methods for macros and folders, loaded by `SettingsManager`                                        |
+| `MacroExecutor.kt`           | Fire-and-forget macro playback: compiles steps to sorted event list, replays with coroutine delays                                                       |
+| `MacroListEditor.kt`         | Full-screen macro library editor: folder sections (collapsible, reorderable), macro reorder within section, context menus for folder CRUD and macro move |
+| `MacroTimelineEditor.kt`     | Single-macro step timeline editor: visual Canvas timeline + step list                                                                                    |
+| `MacroStepEditDialog.kt`     | Modal dialog for creating/editing a single `MacroStep`                                                                                                   |
+| `PadActionPicker.kt`         | Action-type picker; `MacroPicker` uses two-dropdown flow (folder → macro within folder)                                                                  |
+| `PadButtonEditDialog.kt`     | Button create/edit dialog; `initialAction` param for pre-setting Macro action                                                                            |
+| `GamepadInjector.kt`         | Public facade over `ShellGamepadInjector` (incl. `joystick()` for ABS axes)                                                                              |
+| `ShellGamepadInjector.kt`    | Native binary lifecycle + writer thread; handles GD/GU/HD/JS commands                                                                                    |
+| `GamepadKeycodes.kt`         | Linux BTN\_\* + ABS\_\* constants + preset list                                                                                                          |
+| `MouseInjector.kt`           | Public facade over `ShellMouseInjector`                                                                                                                  |
+| `ShellMouseInjector.kt`      | Native binary lifecycle + MOVE-coalescing writer thread for mouse injection                                                                              |
+| `../keyboard/KeyInjector.kt` | Shared key injection facade (reused for `KeyboardKey` actions)                                                                                           |


### PR DESCRIPTION
- add MacroFolder data class to MacroData.kt
- add folderId: String? = null to Macro (backward-compatible)
- extend MacroState with folders StateFlow and full CRUD (addFolder, renameFolder, deleteFolder, reorderFolders, moveMacroToFolder, reorderMacrosInFolder)
- add KEY_MACROPAD_MACRO_FOLDERS, load/save in SettingsManager
- rewrite MacroListView with collapsible folder sections: "Nicht zugeordnet" fixed at top, named folders below drag-reorder scoped per section, folder order via context menu context menus on folder headers (rename/delete/up/down) context menus on macro rows (edit/duplicate/move/delete) new-folder button in top bar, per-section "New Macro" chip new-macro inherits folderId of the section it was created in duplicate macro preserves original folderId
- replace MacroPicker with two-dropdown flow (folder → macro)
- add 11 new strings (EN + DE) for all folder UI