### PR TITLE
feat: add log report export to Settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 | `docs/features/FEATURE_TEMPLATE.md`        | Template for new feature documentation                                                   |
 | `docs/features/theming/FEATURE.md`         | Design System — AppColors, Typography, AppDimens, ColorScheme bridge                     |
 | `docs/features/privileged-mode/FEATURE.md` | Privileged Mode — on-device privileged daemon, ADB-Wireless bootstrap, per-feature flags |
+| `docs/features/log-report/FEATURE.md`      | Log Report Export — save logcat output to a file for bug reports                         |
 
 > [!IMPORTANT]
 > **Documentation language: English only.**

--- a/app/src/main/java/com/stormpanda/megingiard/MainActivity.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.LocaleManager
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.Build
 import android.os.LocaleList
 import android.os.Process
 import android.view.Display
@@ -31,7 +32,10 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.stormpanda.megingiard.config.ConfigManager
 import com.stormpanda.megingiard.config.ExportMetadata
 import com.stormpanda.megingiard.config.MGRD_MIME_TYPE
+import com.stormpanda.megingiard.log.LogReportManager
 import com.stormpanda.megingiard.macropad.MacroExecutor
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import com.stormpanda.megingiard.macropad.MacroPadState
 import com.stormpanda.megingiard.mirror.ACTION_START_PRIVD
 import com.stormpanda.megingiard.mirror.ACTION_STOP
@@ -105,6 +109,40 @@ class MainActivity : ComponentActivity() {
             return@registerForActivityResult
         }
         ConfigManager.setPendingInAppUri(uri)
+    }
+
+    private val createLogDocumentLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("text/plain")
+    ) { uri ->
+        AppStateManager.setFilePickerOpen(false)
+        if (uri == null) return@registerForActivityResult
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching {
+                val pid = Process.myPid()
+                val header = LogReportManager.buildReportHeader(
+                    appVersion = BuildConfig.VERSION_NAME,
+                    deviceModel = Build.MODEL,
+                    androidVersion = Build.VERSION.RELEASE,
+                    timestamp = LocalDateTime.now()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                )
+                val body = LogReportManager.readLogcatLines(pid)
+                contentResolver.openOutputStream(uri)?.use { stream ->
+                    stream.bufferedWriter().use { writer ->
+                        writer.write(header)
+                        writer.write(body)
+                    }
+                } ?: error("Could not open output stream for $uri")
+            }
+                .onSuccess {
+                    AppLog.i(TAG, "Log report written to $uri")
+                    LogReportManager.setSaveResult(LogReportManager.SaveResult.Success)
+                }
+                .onFailure { e ->
+                    AppLog.e(TAG, "Log report save failed", e)
+                    LogReportManager.setSaveResult(LogReportManager.SaveResult.Failure(e.message))
+                }
+        }
     }
 
     // The manifest declares configChanges that prevent activity recreation when the app
@@ -205,6 +243,17 @@ class MainActivity : ComponentActivity() {
                     // show an empty list. With "*/*" all files are visible and the user
                     // can navigate to their .mgrd file.
                     openDocumentLauncher.launch(arrayOf("*/*"))
+                }
+            }
+        }
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                LogReportManager.saveRequest.collect {
+                    val timestamp = LocalDateTime.now()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"))
+                    val filename = LogReportManager.buildReportFilename(timestamp)
+                    AppStateManager.setFilePickerOpen(true)
+                    createLogDocumentLauncher.launch(filename)
                 }
             }
         }

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
@@ -320,7 +320,7 @@ internal fun LanguagePickerRow(
  * location via the SAF "Create Document" picker.
  */
 @Composable
-internal fun SendLogReportRow(
+internal fun SaveLogReportRow(
     accentColor: Color,
     colors: AppColors,
     onClick: () -> Unit,

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt
@@ -312,6 +312,42 @@ internal fun LanguagePickerRow(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Log report row
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Settings row that triggers saving a plain-text log report to a user-chosen
+ * location via the SAF "Create Document" picker.
+ */
+@Composable
+internal fun SendLogReportRow(
+    accentColor: Color,
+    colors: AppColors,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colors.surface)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SettingLabelColumn(
+            label = stringResource(R.string.settings_save_log_report),
+            subtitle = stringResource(R.string.settings_save_log_report_desc),
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+            contentDescription = null,
+            tint = accentColor,
+            modifier = Modifier.size(GS_ACCENT_ARROW_SIZE),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Config export/import row
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
@@ -57,6 +57,7 @@ import com.stormpanda.megingiard.R
 import com.stormpanda.megingiard.config.ConfigManager
 import com.stormpanda.megingiard.config.ExportMetadata
 import com.stormpanda.megingiard.config.MegingiardExport
+import com.stormpanda.megingiard.log.LogReportManager
 import com.stormpanda.megingiard.macropad.MacroPadState
 import com.stormpanda.megingiard.privd.DeadzoneDialog
 import com.stormpanda.megingiard.privd.PrivdSettingsCard
@@ -110,6 +111,7 @@ fun GlobalSettingsScreen(
     var showColorPicker by rememberSaveable { mutableStateOf(false) }
     // Export-result feedback (set by ConfigManager after MainActivity writes the file)
     val exportResult by ConfigManager.exportResult.collectAsState()
+    val logReportSaveResult by LogReportManager.saveResult.collectAsState()
     // All dialog states are hoisted here so they can be rendered at the top-level Box
     // (in-tree, covering the Scaffold). AlertDialog creates a new Android sub-window
     // whose token is null inside MirrorPresentation → BadTokenException crash.
@@ -229,6 +231,12 @@ fun GlobalSettingsScreen(
                             accentColor = effectiveAccent,
                             colors = colors,
                             onChanged = { viewModel.setLogLevel(it) }
+                        )
+                        HorizontalDivider(color = colors.divider)
+                        SendLogReportRow(
+                            accentColor = effectiveAccent,
+                            colors = colors,
+                            onClick = { viewModel.requestSaveLogReport() }
                         )
                         HorizontalDivider(color = colors.divider)
                         RememberSettingRow(
@@ -430,6 +438,29 @@ fun GlobalSettingsScreen(
                     colors = colors,
                     accentColor = effectiveAccent,
                     onDismiss = { ConfigManager.clearExportResult() },
+                )
+            }
+            null -> {}
+        }
+        when (val logResult = logReportSaveResult) {
+            is LogReportManager.SaveResult.Success -> {
+                InTreeMessageDialog(
+                    title = stringResource(R.string.config_success_title),
+                    text = stringResource(R.string.log_report_save_success),
+                    buttonText = stringResource(R.string.config_ok),
+                    colors = colors,
+                    accentColor = effectiveAccent,
+                    onDismiss = { LogReportManager.clearSaveResult() },
+                )
+            }
+            is LogReportManager.SaveResult.Failure -> {
+                InTreeMessageDialog(
+                    title = stringResource(R.string.config_error_title),
+                    text = logResult.message?.takeIf { it.isNotBlank() } ?: stringResource(R.string.log_report_save_error),
+                    buttonText = stringResource(R.string.config_ok),
+                    colors = colors,
+                    accentColor = effectiveAccent,
+                    onDismiss = { LogReportManager.clearSaveResult() },
                 )
             }
             null -> {}

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
@@ -233,7 +233,7 @@ fun GlobalSettingsScreen(
                             onChanged = { viewModel.setLogLevel(it) }
                         )
                         HorizontalDivider(color = colors.divider)
-                        SendLogReportRow(
+                        SaveLogReportRow(
                             accentColor = effectiveAccent,
                             colors = colors,
                             onClick = { viewModel.requestSaveLogReport() }

--- a/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt
@@ -85,7 +85,7 @@ private val GS_SECTION_HEADER_PADDING_H = 16.dp
 private val GS_SECTION_HEADER_PADDING_V = 10.dp
 
 private enum class SettingsSectionFilter {
-    GENERAL, APPEARANCE, DATA, CONFIGURATION, PRIVILEGED_MODE
+    GENERAL, APPEARANCE, DATA, CONFIGURATION, PRIVILEGED_MODE, DIAGNOSTICS
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -173,6 +173,7 @@ fun GlobalSettingsScreen(
                     onSelectData = { selectedSectionFilter = SettingsSectionFilter.DATA },
                     onSelectConfig = { selectedSectionFilter = SettingsSectionFilter.CONFIGURATION },
                     onSelectPrivilegedMode = { selectedSectionFilter = SettingsSectionFilter.PRIVILEGED_MODE },
+                    onSelectDiagnostics = { selectedSectionFilter = SettingsSectionFilter.DIAGNOSTICS },
                 )
                 if (selectedSectionFilter == null || selectedSectionFilter == SettingsSectionFilter.GENERAL) {
                     SettingsSection(
@@ -224,19 +225,6 @@ fun GlobalSettingsScreen(
                             accentColor = effectiveAccent,
                             colors = colors,
                             onChanged = { viewModel.setAppLanguage(it) }
-                        )
-                        HorizontalDivider(color = colors.divider)
-                        LogLevelPickerRow(
-                            logLevel = logLevel,
-                            accentColor = effectiveAccent,
-                            colors = colors,
-                            onChanged = { viewModel.setLogLevel(it) }
-                        )
-                        HorizontalDivider(color = colors.divider)
-                        SaveLogReportRow(
-                            accentColor = effectiveAccent,
-                            colors = colors,
-                            onClick = { viewModel.requestSaveLogReport() }
                         )
                         HorizontalDivider(color = colors.divider)
                         RememberSettingRow(
@@ -313,6 +301,27 @@ fun GlobalSettingsScreen(
                             viewModel = viewModel,
                             onShowWizard = { showPrivdWizard = true },
                             onShowDeadzoneDialog = { showDeadzoneDialog = true },
+                        )
+                    }
+                }
+
+                if (selectedSectionFilter == null || selectedSectionFilter == SettingsSectionFilter.DIAGNOSTICS) {
+                    SettingsSection(
+                        title = stringResource(R.string.settings_section_diagnostics),
+                        accentColor = effectiveAccent,
+                        colors = colors,
+                    ) {
+                        LogLevelPickerRow(
+                            logLevel = logLevel,
+                            accentColor = effectiveAccent,
+                            colors = colors,
+                            onChanged = { viewModel.setLogLevel(it) }
+                        )
+                        HorizontalDivider(color = colors.divider)
+                        SaveLogReportRow(
+                            accentColor = effectiveAccent,
+                            colors = colors,
+                            onClick = { viewModel.requestSaveLogReport() }
                         )
                     }
                 }
@@ -479,6 +488,7 @@ private fun SectionJumpRow(
     onSelectData: () -> Unit,
     onSelectConfig: () -> Unit,
     onSelectPrivilegedMode: () -> Unit,
+    onSelectDiagnostics: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -535,6 +545,13 @@ private fun SectionJumpRow(
             accentColor = accentColor,
             selected = selectedSectionFilter == SettingsSectionFilter.PRIVILEGED_MODE,
             onClick = onSelectPrivilegedMode,
+        )
+        SectionJumpChip(
+            label = stringResource(R.string.settings_jump_diagnostics),
+            colors = colors,
+            accentColor = accentColor,
+            selected = selectedSectionFilter == SettingsSectionFilter.DIAGNOSTICS,
+            onClick = onSelectDiagnostics,
         )
     }
 }

--- a/app/src/main/java/com/stormpanda/megingiard/viewmodel/GlobalSettingsViewModel.kt
+++ b/app/src/main/java/com/stormpanda/megingiard/viewmodel/GlobalSettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.stormpanda.megingiard.privd.PrivdBootstrapper
 import com.stormpanda.megingiard.privd.PrivdError
 import com.stormpanda.megingiard.privd.PrivdManager
 import com.stormpanda.megingiard.privd.PrivdState
+import com.stormpanda.megingiard.log.LogReportManager
 import com.stormpanda.megingiard.settings.AppLanguage
 import com.stormpanda.megingiard.settings.MacroPadSettings
 import com.stormpanda.megingiard.settings.SettingsManager
@@ -59,6 +60,7 @@ class GlobalSettingsViewModel : ViewModel() {
     fun setOverlayAtBottom(value: Boolean) = SettingsManager.setOverlayAtBottom(value)
     fun setAppLanguage(value: AppLanguage) = SettingsManager.setAppLanguage(value)
     fun setLogLevel(value: AppLog.Level) = SettingsManager.setLogLevel(value)
+    fun requestSaveLogReport() = LogReportManager.requestSaveReport()
     fun setShowNavigationCoachMarks(value: Boolean) = SettingsManager.setShowNavigationCoachMarks(value)
     fun setShowMirrorControlLabels(value: Boolean) = SettingsManager.setShowMirrorControlLabels(value)
     fun setShowFullscreenExitHints(value: Boolean) = SettingsManager.setShowFullscreenExitHints(value)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -566,7 +566,6 @@ Einstellungen öffnen, um ein Layout zu erstellen.</string>
     <!-- Log-Bericht exportieren -->
     <string name="settings_save_log_report">Log-Bericht speichern</string>
     <string name="settings_save_log_report_desc">Aktuelle Logcat-Ausgabe als .txt-Datei für Fehlerberichte speichern</string>
-    <string name="log_report_filename">megingiard_log_%s.txt</string>
     <string name="log_report_save_success">Log-Bericht gespeichert.</string>
     <string name="log_report_save_error">Log-Bericht konnte nicht gespeichert werden.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -442,7 +442,9 @@ Einstellungen öffnen, um ein Layout zu erstellen.</string>
     <string name="settings_jump_data">Daten</string>
     <string name="settings_jump_config">Konfiguration</string>
     <string name="settings_jump_privileged_mode">Priv. Modus</string>
+    <string name="settings_jump_diagnostics">Diagnose</string>
     <string name="settings_section_privileged_mode">Privilegierter Modus</string>
+    <string name="settings_section_diagnostics">Diagnose</string>
     <string name="settings_section_expand">Abschnitt aufklappen</string>
     <string name="settings_section_collapse">Abschnitt zuklappen</string>
     <string name="settings_name_error_empty">Name darf nicht leer sein.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -562,4 +562,11 @@ Einstellungen öffnen, um ein Layout zu erstellen.</string>
     <string name="macropad_action_group_profile">Profil</string>
     <string name="macropad_action_group_other">Overlays</string>
     <string name="macropad_picker_label_group">Gruppe</string>
+
+    <!-- Log-Bericht exportieren -->
+    <string name="settings_save_log_report">Log-Bericht speichern</string>
+    <string name="settings_save_log_report_desc">Aktuelle Logcat-Ausgabe als .txt-Datei für Fehlerberichte speichern</string>
+    <string name="log_report_filename">megingiard_log_%s.txt</string>
+    <string name="log_report_save_success">Log-Bericht gespeichert.</string>
+    <string name="log_report_save_error">Log-Bericht konnte nicht gespeichert werden.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,7 +558,6 @@ Open Settings to create a layout.</string>
     <!-- Log report export -->
     <string name="settings_save_log_report">Save log report</string>
     <string name="settings_save_log_report_desc">Save recent logcat output to a .txt file for bug reports</string>
-    <string name="log_report_filename">megingiard_log_%s.txt</string>
     <string name="log_report_save_success">Log report saved.</string>
     <string name="log_report_save_error">Failed to save log report.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,7 +381,9 @@ Open Settings to create a layout.</string>
     <string name="settings_jump_data">Data</string>
     <string name="settings_jump_config">Configuration</string>
     <string name="settings_jump_privileged_mode">Privileged Mode</string>
+    <string name="settings_jump_diagnostics">Diagnostics</string>
     <string name="settings_section_privileged_mode">Privileged Mode</string>
+    <string name="settings_section_diagnostics">Diagnostics</string>
     <string name="settings_section_expand">Expand section</string>
     <string name="settings_section_collapse">Collapse section</string>
     <string name="settings_name_error_empty">Name cannot be empty.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,4 +554,11 @@ Open Settings to create a layout.</string>
     <string name="macropad_action_group_profile">Profile</string>
     <string name="macropad_action_group_other">Overlays</string>
     <string name="macropad_picker_label_group">Group</string>
+
+    <!-- Log report export -->
+    <string name="settings_save_log_report">Save log report</string>
+    <string name="settings_save_log_report_desc">Save recent logcat output to a .txt file for bug reports</string>
+    <string name="log_report_filename">megingiard_log_%s.txt</string>
+    <string name="log_report_save_success">Log report saved.</string>
+    <string name="log_report_save_error">Failed to save log report.</string>
 </resources>

--- a/docs/features/log-report/FEATURE.md
+++ b/docs/features/log-report/FEATURE.md
@@ -19,7 +19,7 @@ to be sent to the developer without requiring USB or ADB access.
 
 ### FR-LR1: Log Report Save
 
-- A **Save log report** row MUST be present in Settings → General, immediately after the Log Level picker.
+- A **Log Level** picker and a **Save log report** row MUST be present together in a dedicated **Settings → Diagnostics** section, located at the bottom of the settings screen (after Privileged Mode).
 - Tapping the row MUST open the SAF "Create Document" picker with a pre-filled filename of the form `megingiard_log_<timestamp>.txt`.
 - The saved file MUST contain a plain-text header (app version, device model, Android version, generation timestamp) followed by up to 3 000 recent logcat lines from the app's own process.
 - On success or failure, an in-tree feedback dialog MUST be shown to the user.

--- a/docs/features/log-report/FEATURE.md
+++ b/docs/features/log-report/FEATURE.md
@@ -1,0 +1,100 @@
+# Feature: Log Report Export
+
+> **Related source:**
+>
+> - `domain/src/main/java/com/stormpanda/megingiard/log/` — coordinator singleton
+> - `app/src/main/java/com/stormpanda/megingiard/MainActivity.kt` — SAF launcher + write
+> - `app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsScreen.kt` — UI entry point
+> - `app/src/main/java/com/stormpanda/megingiard/settings/GlobalSettingsComponents.kt` — row composable
+
+---
+
+## Functional Requirements
+
+### Overview
+
+Users can save the most recent logcat output for the Megingiard process to a plain-text
+file using the Android Storage Access Framework (SAF) file picker. This enables bug reports
+to be sent to the developer without requiring USB or ADB access.
+
+### FR-LR1: Log Report Save
+
+- A **Save log report** row MUST be present in Settings → General, immediately after the Log Level picker.
+- Tapping the row MUST open the SAF "Create Document" picker with a pre-filled filename of the form `megingiard_log_<timestamp>.txt`.
+- The saved file MUST contain a plain-text header (app version, device model, Android version, generation timestamp) followed by up to 3 000 recent logcat lines from the app's own process.
+- On success or failure, an in-tree feedback dialog MUST be shown to the user.
+
+### FR-LR2: Scope and Size
+
+- Log output MUST be limited to the Megingiard process via `logcat --pid=<pid>`.
+- The maximum number of included lines MUST be capped at 3 000 (`-t 3000`).
+
+### FR-LR3: No Special Permissions
+
+- The feature MUST NOT require the `READ_LOGS` manifest permission; apps may always read
+  their own process logs via `logcat --pid`.
+
+---
+
+## Technical Implementation
+
+### Architecture
+
+The save flow mirrors the config-export pattern:
+
+```
+User taps "Save log report" (GlobalSettingsScreen)
+      │
+      ▼
+GlobalSettingsViewModel.requestSaveLogReport()
+      │
+      ▼
+LogReportManager.requestSaveReport()   ← emits saveRequest SharedFlow
+      │
+      ▼
+MainActivity (lifecycle-aware collector)
+      │  opens SAF CreateDocument("text/plain")
+      ▼
+createLogDocumentLauncher callback
+      │  Dispatchers.IO: readLogcatLines() + buildReportHeader()
+      │  contentResolver.openOutputStream() → write
+      ▼
+LogReportManager.setSaveResult(Success | Failure)
+      │
+      ▼
+GlobalSettingsScreen (collectAsState) → InTreeMessageDialog feedback
+```
+
+### LogReportManager (`:domain`)
+
+`LogReportManager` is an `object` singleton in `domain/…/log/`.
+
+| Member                                        | Purpose                                                                                    |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `saveRequest: SharedFlow<Unit>`               | One-shot signal to `MainActivity` to open the file picker                                  |
+| `requestSaveReport()`                         | Posted by `GlobalSettingsViewModel`; emits to `saveRequest`                                |
+| `saveResult: StateFlow<SaveResult?>`          | Success/Failure for UI feedback; cleared after dismiss                                     |
+| `setSaveResult(result)` / `clearSaveResult()` | Written by `MainActivity` callback                                                         |
+| `buildReportFilename(timestamp)`              | Pure: `megingiard_log_<timestamp>.txt` (colons/spaces → hyphens/underscores)               |
+| `buildReportHeader(...)`                      | Pure: multi-line text block with app version, device, Android version, timestamp           |
+| `readLogcatLines(pid)`                        | Blocking: runs `logcat -d --pid=<pid> -v time -t 3000`; returns output or an error message |
+
+`readLogcatLines` is blocking I/O and **must** be called from a background thread
+(`Dispatchers.IO` in the `MainActivity` launcher callback).
+
+### SAF File Picker (`:app` — `MainActivity`)
+
+`createLogDocumentLauncher` is a standard `ActivityResultContracts.CreateDocument("text/plain")` launcher registered in `MainActivity`. Its callback:
+
+1. Sets `AppStateManager.setFilePickerOpen(false)`.
+2. If the user cancels (URI is null), returns early.
+3. On `Dispatchers.IO`: calls `LogReportManager.readLogcatLines(pid)` and `buildReportHeader(...)`, writes header + body to the URI via `contentResolver.openOutputStream`.
+4. Posts `LogReportManager.setSaveResult(Success | Failure)`.
+
+`AppStateManager.setFilePickerOpen(true)` is set before launching, consistent with the rest of the file-picker flow, so the focus-policy logic in `MainActivity` correctly disables game-focus while the picker is open.
+
+### Pure Helper Unit Tests (`:domain`)
+
+`LogReportManagerTest` covers `buildReportFilename` and `buildReportHeader` on the JVM
+without any Android framework dependency. Located at
+`domain/src/test/java/com/stormpanda/megingiard/log/LogReportManagerTest.kt`.

--- a/domain/src/main/java/com/stormpanda/megingiard/log/LogReportManager.kt
+++ b/domain/src/main/java/com/stormpanda/megingiard/log/LogReportManager.kt
@@ -109,28 +109,25 @@ object LogReportManager {
      * **Must be called from a background thread** — [ProcessBuilder.start] is
      * a blocking I/O operation.
      *
-     * Returns an error message string (never throws) so the caller can write
-     * the error into the file for diagnostics.
+     * @throws Exception if logcat cannot be started or exits with a non-zero exit code.
+     * The caller is responsible for handling the exception and surfacing a [SaveResult.Failure].
      */
     fun readLogcatLines(pid: Int): String {
-        return try {
-            val process = ProcessBuilder(
-                "logcat",
-                "-d",
-                "--pid=$pid",
-                "-v", LOG_REPORT_FORMAT,
-                "-t", LOG_REPORT_MAX_LINES.toString(),
-            )
-                .redirectErrorStream(true)
-                .start()
-            val output = process.inputStream.bufferedReader().readText()
-            process.waitFor()
-            AppLog.d(TAG, "readLogcatLines: read ${output.lines().size} lines for pid=$pid")
-            output
-        } catch (e: Exception) {
-            val msg = "Failed to read logcat: ${e.javaClass.simpleName}: ${e.message}"
-            AppLog.e(TAG, msg)
-            msg
+        val process = ProcessBuilder(
+            "logcat",
+            "-d",
+            "--pid=$pid",
+            "-v", LOG_REPORT_FORMAT,
+            "-t", LOG_REPORT_MAX_LINES.toString(),
+        )
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            throw RuntimeException("logcat exited with code $exitCode")
         }
+        AppLog.d(TAG, "readLogcatLines: read ${output.lines().size} lines for pid=$pid")
+        return output
     }
 }

--- a/domain/src/main/java/com/stormpanda/megingiard/log/LogReportManager.kt
+++ b/domain/src/main/java/com/stormpanda/megingiard/log/LogReportManager.kt
@@ -1,0 +1,136 @@
+package com.stormpanda.megingiard.log
+
+import com.stormpanda.megingiard.AppLog
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private const val TAG = "LogReportManager"
+
+/** Maximum number of recent logcat lines included in a report. */
+private const val LOG_REPORT_MAX_LINES = 3000
+
+/** Logcat verbosity tag requested for the report. */
+private const val LOG_REPORT_FORMAT = "time"
+
+/**
+ * Coordinates the log-report save flow.
+ *
+ * MainActivity observes [saveRequest] and drives the SAF file picker in
+ * response, mirroring the pattern used by [ConfigManager] for config exports.
+ * The actual logcat read and file write happen in MainActivity so this
+ * singleton stays free of Android Context dependencies.
+ */
+object LogReportManager {
+
+    /** Result of the most recent save attempt; cleared by [clearSaveResult]. */
+    sealed class SaveResult {
+        data object Success : SaveResult()
+        data class Failure(val message: String?) : SaveResult()
+    }
+
+    private val _saveResult = MutableStateFlow<SaveResult?>(null)
+    val saveResult: StateFlow<SaveResult?> = _saveResult.asStateFlow()
+
+    fun setSaveResult(result: SaveResult) {
+        _saveResult.value = result
+    }
+
+    fun clearSaveResult() {
+        _saveResult.value = null
+    }
+
+    // ── Save request (Settings → MainActivity) ────────────────────────────────
+
+    private val _saveRequest = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * Emits a one-shot signal to MainActivity to open the "Create Document"
+     * SAF file picker for saving the log report.
+     */
+    val saveRequest: SharedFlow<Unit> = _saveRequest.asSharedFlow()
+
+    /** Posted by [GlobalSettingsViewModel.requestSaveLogReport] on the main thread. */
+    fun requestSaveReport() {
+        AppLog.d(TAG, "requestSaveReport")
+        _saveRequest.tryEmit(Unit)
+    }
+
+    // ── Pure helpers (usable on any thread, testable on JVM) ─────────────────
+
+    /**
+     * Builds a suggested filename for the log report, e.g.
+     * `megingiard_log_2026-05-18_14-32-00.txt`.
+     *
+     * [timestamp] should be an ISO-8601-style local date-time string
+     * (passed in so the caller can supply a fixed value in tests).
+     */
+    fun buildReportFilename(timestamp: String): String =
+        "megingiard_log_${timestamp.replace(':', '-').replace(' ', '_')}.txt"
+
+    /**
+     * Builds the plain-text header block that precedes the logcat lines.
+     *
+     * All parameters are explicit so the function is pure and easily testable.
+     *
+     * @param appVersion e.g. `"0.2.0-SNAPSHOT"` from [BuildConfig.VERSION_NAME]
+     * @param deviceModel e.g. `"AYN Thor 2"` from [android.os.Build.MODEL]
+     * @param androidVersion e.g. `"14"` from [android.os.Build.VERSION.RELEASE]
+     * @param timestamp e.g. `"2026-05-18 14:32:00"`
+     */
+    fun buildReportHeader(
+        appVersion: String,
+        deviceModel: String,
+        androidVersion: String,
+        timestamp: String,
+    ): String = buildString {
+        appendLine("=== Megingiard Log Report ===")
+        appendLine("App version  : $appVersion")
+        appendLine("Device       : $deviceModel")
+        appendLine("Android      : $androidVersion")
+        appendLine("Generated at : $timestamp")
+        appendLine("Log lines    : last $LOG_REPORT_MAX_LINES")
+        appendLine("=".repeat(30))
+        appendLine()
+    }
+
+    /**
+     * Reads recent logcat output for the current process and returns it as a
+     * [String]. Caps output at [LOG_REPORT_MAX_LINES] lines via `-t`.
+     *
+     * **Must be called from a background thread** — [ProcessBuilder.start] is
+     * a blocking I/O operation.
+     *
+     * Returns an error message string (never throws) so the caller can write
+     * the error into the file for diagnostics.
+     */
+    fun readLogcatLines(pid: Int): String {
+        return try {
+            val process = ProcessBuilder(
+                "logcat",
+                "-d",
+                "--pid=$pid",
+                "-v", LOG_REPORT_FORMAT,
+                "-t", LOG_REPORT_MAX_LINES.toString(),
+            )
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            process.waitFor()
+            AppLog.d(TAG, "readLogcatLines: read ${output.lines().size} lines for pid=$pid")
+            output
+        } catch (e: Exception) {
+            val msg = "Failed to read logcat: ${e.javaClass.simpleName}: ${e.message}"
+            AppLog.e(TAG, msg)
+            msg
+        }
+    }
+}

--- a/domain/src/test/java/com/stormpanda/megingiard/log/LogReportManagerTest.kt
+++ b/domain/src/test/java/com/stormpanda/megingiard/log/LogReportManagerTest.kt
@@ -1,0 +1,111 @@
+package com.stormpanda.megingiard.log
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure helpers in [LogReportManager].
+ *
+ * The SAF coordination (SharedFlow / StateFlow) is not tested here because it
+ * relies on Android framework classes and is covered by integration testing.
+ * Only the pure, JVM-runnable functions are exercised.
+ */
+class LogReportManagerTest {
+
+    // ── buildReportFilename ───────────────────────────────────────────────────
+
+    @Test
+    fun `buildReportFilename replaces colons and spaces`() {
+        val filename = LogReportManager.buildReportFilename("2026-05-18 14:32:00")
+        assertEquals("megingiard_log_2026-05-18_14-32-00.txt", filename)
+    }
+
+    @Test
+    fun `buildReportFilename with underscore timestamp is unchanged`() {
+        val filename = LogReportManager.buildReportFilename("2026-05-18_14-32-00")
+        assertEquals("megingiard_log_2026-05-18_14-32-00.txt", filename)
+    }
+
+    @Test
+    fun `buildReportFilename preserves hyphens and digits`() {
+        val filename = LogReportManager.buildReportFilename("2026-01-01 00:00:00")
+        assertTrue(filename.startsWith("megingiard_log_"))
+        assertTrue(filename.endsWith(".txt"))
+        assertFalse(filename.contains(' '))
+        assertFalse(filename.contains(':'))
+    }
+
+    // ── buildReportHeader ─────────────────────────────────────────────────────
+
+    @Test
+    fun `buildReportHeader contains all supplied fields`() {
+        val header = LogReportManager.buildReportHeader(
+            appVersion = "0.2.0-SNAPSHOT",
+            deviceModel = "AYN Thor 2",
+            androidVersion = "14",
+            timestamp = "2026-05-18 14:32:00",
+        )
+        assertTrue(header.contains("0.2.0-SNAPSHOT"))
+        assertTrue(header.contains("AYN Thor 2"))
+        assertTrue(header.contains("14"))
+        assertTrue(header.contains("2026-05-18 14:32:00"))
+    }
+
+    @Test
+    fun `buildReportHeader contains section separator`() {
+        val header = LogReportManager.buildReportHeader(
+            appVersion = "1.0",
+            deviceModel = "TestDevice",
+            androidVersion = "13",
+            timestamp = "2026-01-01 00:00:00",
+        )
+        assertTrue(header.contains("==="))
+    }
+
+    @Test
+    fun `buildReportHeader mentions max line count`() {
+        val header = LogReportManager.buildReportHeader(
+            appVersion = "1.0",
+            deviceModel = "TestDevice",
+            androidVersion = "13",
+            timestamp = "2026-01-01 00:00:00",
+        )
+        // Verify it documents the 3000-line cap so it survives future changes
+        assertTrue("Header should mention the line limit", header.contains("3000"))
+    }
+
+    @Test
+    fun `buildReportHeader ends with blank line before log body`() {
+        val header = LogReportManager.buildReportHeader(
+            appVersion = "1.0",
+            deviceModel = "TestDevice",
+            androidVersion = "13",
+            timestamp = "2026-01-01 00:00:00",
+        )
+        assertTrue("Header should end with a newline", header.endsWith("\n"))
+    }
+
+    // ── SaveResult sealed class ───────────────────────────────────────────────
+
+    @Test
+    fun `SaveResult Success is distinct from Failure`() {
+        val success = LogReportManager.SaveResult.Success
+        val failure = LogReportManager.SaveResult.Failure("oops")
+        assertEquals("oops", failure.message)
+        // Verify they are different types at compile time via exhaustive when
+        val successLabel = when (success) {
+            is LogReportManager.SaveResult.Success -> "success"
+            is LogReportManager.SaveResult.Failure -> "failure"
+        }
+        assertEquals("success", successLabel)
+    }
+
+    @Test
+    fun `SaveResult Failure with null message`() {
+        val failure = LogReportManager.SaveResult.Failure(null)
+        assertNull(failure.message)
+    }
+}


### PR DESCRIPTION
- Add LogReportManager singleton in :domain (saveRequest SharedFlow, saveResult StateFlow, buildReportHeader/buildReportFilename pure helpers, readLogcatLines blocking helper capped at 3 000 lines via logcat --pid)
- Add createLogDocumentLauncher (SAF CreateDocument text/plain) in MainActivity; reads logcat on Dispatchers.IO and writes header + body to the user-chosen file; sets isFilePickerOpen during picker lifetime
- Add SendLogReportRow composable to GlobalSettingsComponents
- Wire row into GlobalSettingsScreen General section after LogLevel picker; show SaveResult success/error feedback via InTreeMessageDialog
- Add requestSaveLogReport() to GlobalSettingsViewModel
- Add EN + DE strings: settings_save_log_report, settings_save_log_report_desc, log_report_filename, log_report_save_success, log_report_save_error
- Add unit tests for pure helpers in LogReportManagerTest (9 cases)
- Create docs/features/log-report/FEATURE.md
- Add log-report row to Documentation Map in AGENTS.md