### PR TITLE
fix(privd): integrate HiddenApiBypass to fix ADB Wireless pairing on Android 14+

### DIFF
--- a/companion/domain/build.gradle.kts
+++ b/companion/domain/build.gradle.kts
@@ -130,7 +130,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.libadb.android)
     implementation(libs.sun.security.android)
-    implementation(libs.conscrypt.android)
+    api(libs.hiddenapibypass)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/companion/domain/src/main/java/com/stormpanda/megingiard/privd/PrivdAdbConnectionManager.kt
+++ b/companion/domain/src/main/java/com/stormpanda/megingiard/privd/PrivdAdbConnectionManager.kt
@@ -19,6 +19,7 @@ import android.sun.security.x509.X509CertImpl
 import android.sun.security.x509.X509CertInfo
 import com.stormpanda.megingiard.AppLog
 import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 import java.io.File
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
@@ -99,8 +100,20 @@ internal class PrivdAdbConnectionManager private constructor(
             }
         }
 
+        private fun ensureHiddenApiExemptions() {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching {
+                    HiddenApiBypass.addHiddenApiExemptions("L")
+                    AppLog.i(TAG, "ensureHiddenApiExemptions: HiddenApi exemptions applied successfully")
+                }.onFailure { e ->
+                    AppLog.w(TAG, "ensureHiddenApiExemptions: Failed to apply HiddenApi exemptions: $e")
+                }
+            }
+        }
+
         @Synchronized
         fun getInstance(context: Context): PrivdAdbConnectionManager {
+            ensureHiddenApiExemptions()
             instance?.let { return it }
             val (keyAndCert, name) = loadOrCreateCredentials(context.applicationContext)
             return PrivdAdbConnectionManager(keyAndCert.first, keyAndCert.second, name).also { instance = it }

--- a/companion/ui/build.gradle.kts
+++ b/companion/ui/build.gradle.kts
@@ -194,6 +194,7 @@ dependencies {
     implementation(libs.androidx.palette.ktx)
     implementation(libs.reorderable)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.hiddenapibypass)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/companion/ui/src/main/java/com/stormpanda/megingiard/MainActivity.kt
+++ b/companion/ui/src/main/java/com/stormpanda/megingiard/MainActivity.kt
@@ -98,6 +98,7 @@ import com.stormpanda.megingiard.ui.colorSchemeFor
 import com.stormpanda.megingiard.ui.megingiardTypography
 import com.stormpanda.megingiard.ui.paletteFor
 import com.stormpanda.megingiard.update.UpdateManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -204,6 +205,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
         super.onCreate(savedInstanceState)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            runCatching {
+                HiddenApiBypass.addHiddenApiExemptions("L")
+            }
+        }
 
         // Init settings first so the persisted log level is active before anything
         // else runs (including SignatureGuard below). SettingsManager.init() reads

--- a/companion/ui/src/main/java/com/stormpanda/megingiard/services/MegingiardAccessibilityService.kt
+++ b/companion/ui/src/main/java/com/stormpanda/megingiard/services/MegingiardAccessibilityService.kt
@@ -32,6 +32,7 @@ import com.stormpanda.megingiard.privd.PrivdError
 import com.stormpanda.megingiard.privd.PrivdManager
 import com.stormpanda.megingiard.privd.PrivdPairScreenTextScanner
 import com.stormpanda.megingiard.privd.PrivdState
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -79,6 +80,11 @@ class MegingiardAccessibilityService : AccessibilityService() {
 
     override fun onServiceConnected() {
         super.onServiceConnected()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            runCatching {
+                HiddenApiBypass.addHiddenApiExemptions("L")
+            }
+        }
         instance = this
         AppLog.i(TAG, "onServiceConnected: Megingiard Accessibility Service is active")
         AppStateManager.setAccessibilityActive(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ datastorePreferences = "1.1.1"
 reorderable = "2.4.0"
 libadbAndroid = "3.1.1"
 sunSecurityAndroid = "1.1"
-conscrypt = "2.5.0"
+hiddenapibypass = "4.3"
 robolectric = "4.12.2"
 paletteKtx = "1.0.0"
 documentfile = "1.0.1"
@@ -49,7 +49,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 libadb-android = { group = "com.github.MuntashirAkon", name = "libadb-android", version.ref = "libadbAndroid" }
 sun-security-android = { group = "com.github.MuntashirAkon", name = "sun-security-android", version.ref = "sunSecurityAndroid" }
-conscrypt-android = { group = "org.conscrypt", name = "conscrypt-android", version.ref = "conscrypt" }
+hiddenapibypass = { group = "org.lsposed.hiddenapibypass", name = "hiddenapibypass", version.ref = "hiddenapibypass" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]


### PR DESCRIPTION
### Summary
Fixes \NoSuchMethodException: com.android.org.conscrypt.Conscrypt.exportKeyingMaterial\ and blocked hidden API reflection during ADB Wireless Debugging pairing on Android 14/15.

### Root Cause
\libadb-android\ uses Java reflection to invoke \com.android.org.conscrypt.Conscrypt.exportKeyingMaterial\ during TLS 1.3 pairing handshake. On modern Android versions (Android 14+), Android runtime enforces strict non-SDK interface restrictions (\locked, reflection, denied\), causing \pair()\ to throw \NoSuchMethodException\ and fail silently or abort auto-setup.

### Fix
- Integrates \org.lsposed.hiddenapibypass:hiddenapibypass:4.3\.
- Exempts hidden API reflection restrictions on Android P+ in \PrivdAdbConnectionManager\, \MainActivity\, and \MegingiardAccessibilityService\.
- Replaces unused native \conscrypt-android\ dependency with clean runtime hidden API bypass.

### Verification
- Tested and verified on AYN Thor (Android 14/15 dual-screen device).
- Auto-setup ADB pairing succeeds seamlessly.
- All 334 unit tests in \:companion:domain\ pass cleanly.